### PR TITLE
Adds support for --override-zos-tools in manpages

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -175,8 +175,8 @@ writeConfigFile(){
 # relative to this envvar value
 displayHelp() {
 echo "usage: . zopen-config [--eknv] [--knv] [-?|--help]"
-echo "  --override-zos-tools   Adds altbin/ dir to the PATH and altman/ dir to MANPATH, which overrides /bin tools"
-echo "  --nooverride-zos-tools Does not add altbin/ and altman/ dir to PATH and MANPATH"
+echo "  --override-zos-tools   Adds altbin/ dir to the PATH and altman/ dir to MANPATH, overriding the native z/OS tooling."
+echo "  --nooverride-zos-tools Does not add altbin/ and altman/ dir to PATH and MANPATH."
 echo "  --override-zos-tools-subset=<file>"
 echo "      Override a subset of zos tools. Containing a subset of packages to override, delimited by newlines."
 echo "  --knv                  Display zopen environment variables "

--- a/include/common.sh
+++ b/include/common.sh
@@ -175,8 +175,8 @@ writeConfigFile(){
 # relative to this envvar value
 displayHelp() {
 echo "usage: . zopen-config [--eknv] [--knv] [-?|--help]"
-echo "  --override-zos-tools   Adds altbin/ dir to the PATH, which overrides /bin tools"
-echo "  --nooverride-zos-tools Does not add altbin/ dir from PATH"
+echo "  --override-zos-tools   Adds altbin/ dir to the PATH and altman/ dir to MANPATH, which overrides /bin tools"
+echo "  --nooverride-zos-tools Does not add altbin/ and altman/ dir to PATH and MANPATH"
 echo "  --override-zos-tools-subset=<file>"
 echo "      Override a subset of zos tools. Containing a subset of packages to override, delimited by newlines."
 echo "  --knv                  Display zopen environment variables "
@@ -284,6 +284,7 @@ if [ -z "\${ZOPEN_QUICK_LOAD}" ]; then
 fi
 unset displayText
 PATH=\${ZOPEN_ROOTFS}/usr/local/bin:\${ZOPEN_ROOTFS}/usr/bin:\${ZOPEN_ROOTFS}/bin:\${ZOPEN_ROOTFS}/boot:\$(sanitizeEnvVar "\${PATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
+MANPATH=\${ZOPEN_ROOTFS}/usr/local/share/man:\${ZOPEN_ROOTFS}/usr/local/share/man/\%L:\${ZOPEN_ROOTFS}/usr/share/man:\${ZOPEN_ROOTFS}/usr/share/man/\%L:\$(sanitizeEnvVar "\${MANPATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
 
 if [ -n "\$ZOPEN_TOOLSET_OVERRIDE" ]; then
   if [ -n "\${overrideFile}" ] && [ -f "\${overrideFile}" ]; then
@@ -292,19 +293,23 @@ if [ -n "\$ZOPEN_TOOLSET_OVERRIDE" ]; then
       if [ -d "\$ZOPEN_PKGINSTALL/\$project/\$project/altbin" ]; then
         PATH="\$ZOPEN_PKGINSTALL/\$project/\$project/altbin:\$PATH"
       fi
+      if [ -d "\$ZOPEN_PKGINSTALL/\$project/\$project/share/altman" ]; then
+        MANPATH="\$ZOPEN_PKGINSTALL/\$project/\$project/share/altman:\$MANPATH"
+      fi
     done < "\${overrideFile}"
   else
     PATH="\${ZOPEN_ROOTFS}/usr/local/altbin:\$PATH"
+    MANPATH="\${ZOPEN_ROOTFS}/usr/local/share/altman:\$MANPATH"
   fi
 else
   PATH=\$(sanitizeEnvVar "\${PATH}" ":" "^\${ZOPEN_ROOTFS}/usr/local/altbin.*\$")
+  MANPATH=\$(sanitizeEnvVar "\${MANPATH}" ":" "^\${ZOPEN_ROOTFS}/usr/local/share/altman.*\$")
 fi
 
 
 export PATH=\$(deleteDuplicateEntries "\${PATH}" ":")
 LIBPATH=\${ZOPEN_ROOTFS}/usr/local/lib:\${ZOPEN_ROOTFS}/usr/lib:\$(sanitizeEnvVar "\${LIBPATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
 export LIBPATH=\$(deleteDuplicateEntries "\${LIBPATH}" ":")
-MANPATH=\${ZOPEN_ROOTFS}/usr/local/share/man:\${ZOPEN_ROOTFS}/usr/local/share/man/\%L:\${ZOPEN_ROOTFS}/usr/share/man:\${ZOPEN_ROOTFS}/usr/share/man/\%L:\$(sanitizeEnvVar "\${MANPATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
 export MANPATH=\$(deleteDuplicateEntries "\${MANPATH}" ":")
 
 if \${knv}; then


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen framework
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
Adds support to zopen-config such that altman is added to the MANPATH. The conflicting tools will be updated accordingly.

## Related Issues

- Related Issue # https://github.com/zopencommunity/meta/issues/865

## [optional] Are there any post-deployment tasks or follow-up actions required?
* Merge the following PRs:  
  * https://github.com/zopencommunity/tarport/pull/20
  * https://github.com/zopencommunity/man-dbport/pull/65
  * coreutils - https://github.com/zopencommunity/coreutilsport/compare/zotman?expand=1
  * Sed - https://github.com/zopencommunity/sedport/pull/15
  * findutils -https://github.com/zopencommunity/findutilsport/pull/22
  * diffutils - https://github.com/zopencommunity/diffutilsport/pull/33
  * Grep - https://github.com/zopencommunity/grepport/pull/19
  * Make - pushed to main
  * https://github.com/zopencommunity/opensshport/pull/14/files
  * https://github.com/zopencommunity/gawkport/pull/26