### PR TITLE
Improve error messages when out of space

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -403,7 +403,7 @@ handlePackageInstall()
     killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"
     
-    checkAvailableSize ${megabytes}
+    checkAvailableSize ${name} ${size}
     if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
       printError "Could not download from ${downloadURL}. Correct any errors and potentially retry."
       continue
@@ -434,8 +434,8 @@ handlePackageInstall()
       printInfo "- Local install specified."
       paxredirect="-s %[^/]*/%${installdirname}/%"
       printVerbose "Non-local install, extracting with '${paxredirect}'"
-    fi 
-        
+    fi
+ 
     megabytes=$(echo "scale=2; ${expanded_size} / (1024 * 1024)" | bc)
     printInfo "After this operation, ${megabytes} MB of additional disk space will be used."
     if ! promptYesOrNo "Do you want to continue?" ${yesToPrompts}; then

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -379,6 +379,11 @@ handlePackageInstall()
     printVerbose "Checking cache for already downloaded package [file name comparison]."
     location="zopen package cache"
   fi
+
+  # Check partition size before download package
+  megabytes=$(echo "scale=2; ${size} / (1024 * 1024)" | bc)
+  checkAvailableSize ${megabytes}
+
   # Download the metadata json file
   if ! runAndLog "curlCmd -L '${metadataJSONURL}' -o '${metadataFile}'" ${redirectToDevNull}; then
     printError "Could not download from ${metadataJSONURL}. Correct any errors and potentially retry."
@@ -397,7 +402,8 @@ handlePackageInstall()
     ph=$!
     killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"
-
+    
+    checkAvailableSize ${megabytes}
     if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
       printError "Could not download from ${downloadURL}. Correct any errors and potentially retry."
       continue
@@ -430,7 +436,6 @@ handlePackageInstall()
       printVerbose "Non-local install, extracting with '${paxredirect}'"
     fi
 
-    megabytes=$(echo "scale=2; ${size} / (1024 * 1024)" | bc)
     printInfo "After this operation, ${megabytes} MB of additional disk space will be used."
     if ! promptYesOrNo "Do you want to continue?" ${yesToPrompts}; then
       mutexFree "zopen"

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -316,7 +316,8 @@ handlePackageInstall()
 
   downloadURL=$(/bin/printf "%s" "${asset}" | jq -e -r '.url')
   metadataJSONURL="$(dirname "${downloadURL}")/metadata.json"
-  size=$(/bin/printf "%s" "${asset}" | jq -e -r '.expanded_size')
+  expanded_size=$(/bin/printf "%s" "${asset}" | jq -e -r '.expanded_size')
+  size=$(/bin/printf "%s" "${asset}" | jq -e -r '.size')
 
   if [ -z "${downloadURL}" ]; then
     printError "Unable to determine download location for ${name}"
@@ -381,8 +382,7 @@ handlePackageInstall()
   fi
 
   # Check partition size before download package
-  megabytes=$(echo "scale=2; ${size} / (1024 * 1024)" | bc)
-  checkAvailableSize ${megabytes}
+  checkAvailableSize ${name} ${size}
 
   # Download the metadata json file
   if ! runAndLog "curlCmd -L '${metadataJSONURL}' -o '${metadataFile}'" ${redirectToDevNull}; then
@@ -434,8 +434,9 @@ handlePackageInstall()
       printInfo "- Local install specified."
       paxredirect="-s %[^/]*/%${installdirname}/%"
       printVerbose "Non-local install, extracting with '${paxredirect}'"
-    fi
-
+    fi 
+        
+    megabytes=$(echo "scale=2; ${expanded_size} / (1024 * 1024)" | bc)
     printInfo "After this operation, ${megabytes} MB of additional disk space will be used."
     if ! promptYesOrNo "Do you want to continue?" ${yesToPrompts}; then
       mutexFree "zopen"

--- a/include/common.sh
+++ b/include/common.sh
@@ -1332,9 +1332,11 @@ isURLReachable() {
 
 checkAvailableSize()
 { 
-  printInfo "Checking available size to install package."
   
-  packageSize="$1"
+  package="$1"
+  printInfo "Checking available size to install ${package}."
+
+  packageSize=$(echo "scale=2; $2 / (1024 * 1024)" | bc)
   partitionSize=$(/bin/df -m . | tail -1 | awk '{print $3}' | cut -f1 -d '/')
   
   printDebug "Package Size: ${packageSize} MB"
@@ -1343,7 +1345,7 @@ checkAvailableSize()
   if [ 1 -eq "$(echo "${packageSize} > ${partitionSize}" | bc)" ]; then
     printError "Not enough space in partition."
   fi
-  printInfo "Enough space to install package. Proceeding installation."
+  printInfo "Enough space to install ${package}. Proceeding installation."
   return 0
 }
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -1341,8 +1341,7 @@ checkAvailableSize()
   printDebug "Partition Size: ${partitionSize} MB"
 
   if [ 1 -eq "$(echo "${packageSize} > ${partitionSize}" | bc)" ]; then
-    printInfo "Not enough space in partition."
-    return 1
+    printError "Not enough space in partition."
   fi
   printInfo "Enough space to install package. Proceeding installation."
   return 0

--- a/include/common.sh
+++ b/include/common.sh
@@ -1333,15 +1333,18 @@ isURLReachable() {
 checkAvailableSize()
 { 
   printInfo "Checking available size to install package."
- 
-  partitionSize=$(df -m . | tail -1 | awk '{print $3}' | cut -f1 -d '/') 
   
-  printDebug "Package Size: $1"
-  printDebug "Partition Size: ${partitionSize}"
-  if [[ $packageSize > $partitionSize ]] ; then
+  packageSize="$1"
+  partitionSize=$(df -m . | tail -1 | awk '{print $3}' | cut -f1 -d '/')
+  
+  printDebug "Package Size: ${packageSize} MB"
+  printDebug "Partition Size: ${partitionSize} MB"
+
+  if [ 1 -eq "$(echo "${packageSize} > ${partitionSize}" | bc)" ]; then
     printInfo "Not enough space in partition."
     return 1
   fi
+  printInfo "Enough space to install package. Proceeding installation."
   return 0
 }
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -1330,6 +1330,21 @@ isURLReachable() {
   fi
 }
 
+checkAvailableSize()
+{ 
+  printInfo "Checking available size to install package."
+ 
+  partitionSize=$(df -m . | tail -1 | awk '{print $3}' | cut -f1 -d '/') 
+  
+  printDebug "Package Size: $1"
+  printDebug "Partition Size: ${partitionSize}"
+  if [[ $packageSize > $partitionSize ]] ; then
+    printInfo "Not enough space in partition."
+    return 1
+  fi
+  return 0
+}
+
 promptYesOrNo() {
   message="$1"
   skip=$2

--- a/include/common.sh
+++ b/include/common.sh
@@ -1335,7 +1335,7 @@ checkAvailableSize()
   printInfo "Checking available size to install package."
   
   packageSize="$1"
-  partitionSize=$(df -m . | tail -1 | awk '{print $3}' | cut -f1 -d '/')
+  partitionSize=$(/bin/df -m . | tail -1 | awk '{print $3}' | cut -f1 -d '/')
   
   printDebug "Package Size: ${packageSize} MB"
   printDebug "Partition Size: ${partitionSize} MB"


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
This PR aims to add a function that will check available partition size before install any package. If not enough space, a message will be displayed so the user has better knowledge on why the process failed.

## Related Issues

- Related Issue #859
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
