### PR TITLE
Add error checking in zopen-build setup.sh and only replace hardcoded paths in text files (not binary files)

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1483,7 +1483,7 @@ createEnvAndSetup()
   cat << zz > "${ZOPEN_INSTALL_DIR}/.env"
 if ! [ -f ./.env ]; then
   echo "Need to source from the .env directory" >&2
-  return 0
+  return 1
 fi
 
 dropTagRedirEnvar=false
@@ -1544,6 +1544,7 @@ zz
   cat << zz > "${ZOPEN_INSTALL_DIR}/setup.sh"
 #!/bin/sh
 touch \".installing\"
+SETUPDIR="\$(cd "\$(dirname "\$0")" > /dev/null 2>&1 && pwd -P)"
 . ./.env
 echo \"Setting up ${projectName_lower}...\"
 zz
@@ -1561,20 +1562,34 @@ replaceHardcodedPath() {
   replaced=\$2
   root=\$3
   f=\$4
-  if [ \"\$f\" != \"\${root}/setup.sh\" ] && [ \"\$f\" != \"\${root}/.env\" ]; then
-    isWritable=true
-    if [ ! -w "\$f" ]; then
-      isWriteable=false
-      chmod "+w" \$f
-    fi
-    cp \$f \$f.tmp && \\
-    /bin/sed -e \"s#\${orig}#\${replaced}#g\" \$f.tmp > \$f && \\
-    rm \$f.tmp;
-    if ! \$isWriteable; then
-      chmod "-w" \$f
+  # only substitute text files
+  if /bin/sed -e "" \${f} 2> /dev/null 1>&2; then
+    if [ \"\$f\" != \"\${root}/setup.sh\" ] && [ \"\$f\" != \"\${root}/.env\" ] && [ \"\$f\" != \"\${root}/.replacedpath\" ]; then
+      isWritable=true
+      if [ ! -w "\$f" ]; then
+        isWriteable=false
+        chmod "+w" \$f
+      fi
+      cp \$f \$f.tmp && \\
+      /bin/sed -e \"s#\${orig}#\${replaced}#g\" \$f.tmp > \$f && \\
+      rm -f \$f.tmp;
+      if ! \$isWriteable; then
+        chmod "-w" \$f
+      fi
     fi
   fi
 }
+if [ ! -d "\$${projectName}_HOME" ]; then
+  echo "WARNING: ${projectName}_HOME (set to \"\$${projectName}_HOME\") was not set properly."
+  ${projectName}_HOME="\${SETUPDIR}"
+fi
+
+if [ ! -d "\$${projectName}_HOME" ]; then
+  echo "ERROR: ${projectName}_HOME (set to \"\$${projectName}_HOME\") is not a directory. Exiting."
+  exit 2
+fi
+
+echo "Replacing hardcoded paths in \$${projectName}_HOME..."
 ZOPEN_INSTALL_PREFIX="\$${projectName}_HOME/../../"
 ZOPEN_INSTALL_PREFIX=\$(cd "\${ZOPEN_INSTALL_PREFIX}" >/dev/null 2>&1 && pwd -P)
 for f in \$(/bin/find \$${projectName}_HOME/ -type f | /bin/xargs grep -l \"\$REPLACE_PREFIX_PATH\" 2>/dev/null); do


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
* Adds error checking in zopen-build generated setup.sh file and some verbose output for reference if an issue does occur with setup.sh
* Also restricts path replacement to text files only, avoiding binary files

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
