### PR TITLE
Mark initialization files as IBM-1047

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -26,34 +26,6 @@ setupMyself()
 }
 setupMyself
 
-#
-# Functions section
-#
-
-#
-# asciiecho: we are in the process of starting to use 'echo' from coreutils.
-# This echo will have a slightly different behaviour than the standard echo in that
-# the file will now be tagged as ascii instead of ebcdic
-# For compatibility, check the tag of the file after the echo and iconv the file IFF it is IBM-1047
-#
-
-asciiecho()
-{
-  text="$1"
-  file="$2"
-
-  if ! echo "${text}" > "${file}"; then
-    echo "Unable to echo text to ${file}" >&2
-    return 2
-  fi
-  if [ "$(chtag -p "${file}" | cut -f2 -d' ')" = "IBM-1047" ]; then
-    if ! /bin/iconv -f IBM-1047 -t ISO8859-1 < "${file}" > "${file}_ascii" || ! chtag -tc ISO8859-1 "${file}_ascii" || ! mv "${file}_ascii" "${file}"; then
-      printError "Unable to convert EBCDIC text to ASCII for ${file}" >&2
-    fi
-  fi
-  return 0
-}
-
 printEnvVar()
 {
   echo "User-Provided environment variables:
@@ -1506,7 +1478,10 @@ _CEE_RUNOPTS="\$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
 # Remove spaces in between brackets
 _CEE_RUNOPTS="\$(echo "\$_CEE_RUNOPTS" | awk '{gsub(/\([ \t]*/, "("); gsub(/[ \t]*\)/, ")"); gsub(/[ \t]*,[ \t]*/, ","); print}')"
 export _CEE_RUNOPTS="\$(deleteDuplicateEntries "\$_CEE_RUNOPTS" " ")"
-export _BPXK_AUTOCVT=ON
+
+if [ -z "${_BPXK_AUTOCVT}" ] || [ "${_BPXK_AUTOCVT}" = "OFF" ]; then
+  export _BPXK_AUTOCVT=ON
+fi
 
 export ${projectName}_HOME="\${PWD}"
 zz
@@ -1657,6 +1632,7 @@ ZZ
     cat << ZZ >> "${ZOPEN_INSTALL_DIR}/.depsenv"
 OLDPWD="\$${varName}_originalDir"
 ZZ
+  a2e ${ZOPEN_INSTALL_DIR}/.depsenv
   fi
 
   # Add call to setup.sh
@@ -1666,6 +1642,11 @@ if [ ! -f \".installed\" ] && [ ! -f \".installing\" ] && [ -x \"setup.sh\" ]; t
   ./setup.sh
 fi
 zz
+
+  # Zopen "entry point" files should be in IBM-1047
+  a2e ${ZOPEN_INSTALL_DIR}/setup.sh
+  a2e ${ZOPEN_INSTALL_DIR}/.appenv
+  a2e ${ZOPEN_INSTALL_DIR}/.env
 
   chmod 755 "${ZOPEN_INSTALL_DIR}/setup.sh"
 }

--- a/include/common.sh
+++ b/include/common.sh
@@ -1369,6 +1369,10 @@ promptYesOrNo() {
   return 0
 }
 
+# asciiecho: we are in the process of starting to use 'echo' from coreutils.
+# This echo will have a slightly different behaviour than the standard echo in that
+# the file will now be tagged as ascii instead of ebcdic
+# For compatibility, check the tag of the file after the echo and iconv the file IFF it is IBM-1047
 asciiecho()
 {
   text="$1"

--- a/include/common.sh
+++ b/include/common.sh
@@ -1369,6 +1369,38 @@ promptYesOrNo() {
   return 0
 }
 
+asciiecho()
+{
+  text="$1"
+  file="$2"
+
+  if ! echo "${text}" > "${file}"; then
+    echo "Unable to echo text to ${file}" >&2
+    return 2
+  fi
+  if [ "$(chtag -p "${file}" | cut -f2 -d' ')" = "IBM-1047" ]; then
+    if ! /bin/iconv -f IBM-1047 -t ISO8859-1 < "${file}" > "${file}_ascii" || ! chtag -tc ISO8859-1 "${file}_ascii" || ! mv "${file}_ascii" "${file}"; then
+      printError "Unable to convert EBCDIC text to ASCII for ${file}" >&2
+    fi
+  fi
+  return 0
+}
+
+a2e() 
+{
+  source="$1"
+
+  if [ ! -w "${source}" ]; then
+    printWarning "Cannot write to ${source}"
+    return;
+  fi
+
+  if [ "$(chtag -p "${source}" | cut -f2 -d' ')" = "ISO8859-1" ]; then
+    /bin/iconv -f ISO8859-1 -t IBM-1047 "$source" > "$source.bk"
+    chtag -tc 1047 "$source.bk"
+    mv "$source.bk" "$source"
+  fi
+}
 
 . ${INCDIR}/analytics.sh
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
The default codepage is IBM-1047, therefore we should provide all entrypoint files in IBM-1047. This would mean all env scripts, as they can then set AUTOCVT=ON.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
