### PR TITLE
Allow specification of specific patch directory

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -122,6 +122,7 @@ Optional:
                               CPPFLAGS options but will get them from env vars.
   ZOPEN_MAKE_OPTS             Options to pass to build program.
                               (defaults to '-j\${ZOPEN_NUM_JOBS}')
+  ZOPEN_PATCH_DIR             Specify directory from which patches should be applied.
 
 Optional settings for installation:
   ZOPEN_RUNTIME_DEPS          Runtime z/OS Open Tool dependencies to be installed
@@ -1137,19 +1138,29 @@ applyPatches()
     code_dir="${ZOPEN_ROOT}/${gitname%%.*}"
   fi
 
-  if [ ! -z "${ZOPEN_BUILD_LINE}" ]; then
-    buildtype_lower=$(echo "${ZOPEN_BUILD_LINE}" | tr '[A-Z]' '[a-z]')
-    patch_try_dir="${ZOPEN_ROOT}/${buildtype_lower}-patches"
+  if [ ! -z "${ZOPEN_PATCH_DIR}" ]; then
+    patch_try_dir="${ZOPEN_ROOT}/${ZOPEN_PATCH_DIR}"
     if [ -d "${patch_try_dir}" ]; then
       patch_dir="${patch_try_dir}"
-    fi
-  fi
-
-  if [ -z "${patch_dir}" ]; then
-    patch_dir="${ZOPEN_ROOT}/patches"
-    if ! [ -d "${patch_dir}" ]; then
-      printWarning "${patch_dir} does not exist - no patches to apply"
+    else
+      printWarning "Specified patch directory ${patch_try_dir} does not exist - no patches to apply"
       return 0
+    fi
+  else
+    if [ ! -z "${ZOPEN_BUILD_LINE}" ]; then
+      buildtype_lower=$(echo "${ZOPEN_BUILD_LINE}" | tr '[A-Z]' '[a-z]')
+      patch_try_dir="${ZOPEN_ROOT}/${buildtype_lower}-patches"
+      if [ -d "${patch_try_dir}" ]; then
+        patch_dir="${patch_try_dir}"
+      fi
+    fi
+
+    if [ -z "${patch_dir}" ]; then
+      patch_dir="${ZOPEN_ROOT}/patches"
+      if ! [ -d "${patch_dir}" ]; then
+        printWarning "${patch_dir} does not exist - no patches to apply"
+        return 0
+      fi
     fi
   fi
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
This change allows for builders to specify a specific patch directory to apply from in their build environment configuration. If this variable is left unspecified, the patch directory will be chosen in the same way as before.

## Related Issues

- N/A

## [optional] Are there any post-deployment tasks or follow-up actions required?

- N/A
