### PR TITLE
Avoid gpg temporary files colliding

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -39,11 +39,11 @@ verifySignatureOfPax()
 
 
   # Create a temporary directory for GPG keyring
-  TMP_GPG_DIR="$zopen_tmp_dir/tmp_gpg_verify"
+  TMP_GPG_DIR="$zopen_tmp_dir/zopen_gpg_verify_$LOGNAME_$$"
   mkdir -p "$TMP_GPG_DIR"
 
-  SIGNATURE_FILE="$zopen_tmp_dir/signedfile.asc"
-  PUBLIC_KEY_FILE="$zopen_tmp_dir/scriptpubkey.asc"
+  SIGNATURE_FILE="$zopen_tmp_dir/signedfile.$LOGNAME.$$.asc"
+  PUBLIC_KEY_FILE="$zopen_tmp_dir/scriptpubkey.$LOGNAME.$$.asc"
   printf "%b" "$SIGNATURE" | tr -d '"'  > "$SIGNATURE_FILE"
   printf "%b" "$PUBLIC_KEY" | tr -d '"'  > "$PUBLIC_KEY_FILE"
 
@@ -76,10 +76,11 @@ verifySignatureOfPax()
         printError "Signature file does not exist."
   fi
   
+  printInfo "GPG signature verified."
   # Clean up the temporary directory/files
-  [ -e "${SIGNATURE_FILE}" ] && rm -rf "${SIGNATURE_FILE}"
-  [ -e "${PUBLIC_KEY_FILE}" ] && rm -rf "${PUBLIC_KEY_FILE}"
-  [ -e "${TMP_GPG_DIR}" ] && rm -rf "${TMP_GPG_DIR}"
+  [ -e "${SIGNATURE_FILE}" ] && rm -f "${SIGNATURE_FILE}"
+  [ -e "${PUBLIC_KEY_FILE}" ] && rm -f "${PUBLIC_KEY_FILE}"
+  [ -d "${TMP_GPG_DIR}" ] && rm -rf "${TMP_GPG_DIR}"
 }
 
 printSyntax()


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
My system had two zopen installations. The gpg files were written to the same location which I had no access to.

Got this:
```
rm: FSUM9195 cannot unlink entry "/tmp/tmp_gpg_verify/pubring.kbx": EDC5111I Permission denied.
rm: FSUM9195 cannot unlink entry "/tmp/tmp_gpg_verify/pubring.kbx~": EDC5111I Permission denied.
rm: FSUM9196 cannot remove directory "/tmp/tmp_gpg_verify": EDC5111I Permission denied.
```
This will resolve it

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
