### PR TITLE
Remove redundant `port` in Latest.md generation

### DIFF
--- a/tools/getbinaries.py
+++ b/tools/getbinaries.py
@@ -186,7 +186,7 @@ with open('docs/Latest.md', 'w') as f:
     # Write table for each category
     for category, packages in sorted(packages_by_category.items()):
         print(f"<div class=\"table-category\" data-category=\"{category}\">")
-        print(f"\n## {category.title()} ports <!-- {{docsify-ignore}} -->\n")
+        print(f"\n## {category.title()} <!-- {{docsify-ignore}} -->\n")
         print("| Package | Status | Test Success Rate | Latest Release | Description |")
         print("|---|---|---|---|---|")
         

--- a/tools/getbinaries.py
+++ b/tools/getbinaries.py
@@ -38,10 +38,10 @@ def get_success_rate(passed_tests, total_tests, has_releases):
 
 def write_package_table_row(package, status, success_rate, latest_release, latest_asset, description):
     """Helper function to write a consistent table row"""
-    print(f"| [{package}port](https://github.com/zopencommunity/{package}port)", end='')
+    print(f"| [{package}](https://github.com/zopencommunity/{package}port)", end='')
     print(f"|{status}", end='')
     print(f"|{success_rate:.1f}%" if success_rate >= 0 else "|N/A", end='')
-    print(f"|[{latest_release['tag_name']}]({latest_asset['url']})", end='')
+    print(f"|[{latest_release['tag_name'].replace('port', '')}]({latest_asset['url']})", end='')
     print(f"|{description}|")
 
 def count_patches(repo):


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Content Update

## Category

- [ ] zopen build framework
- [ ] zopen package manager
- [x] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->

Removes `port` in the `Package` and `Latest Release` column... just from the names.  
The links remain the same.

![image](https://github.com/user-attachments/assets/95a1c09f-bb18-4363-ad39-cea2b2071e21)


## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
