### PR TITLE
Invalid option -m passed to df during installs

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -1338,12 +1338,14 @@ checkAvailableSize()
   printInfo "Checking available size to install ${package}."
 
   packageSize=$(echo "scale=2; $2 / (1024 * 1024)" | bc)
-  partitionSize=$(/bin/df -m . | tail -1 | awk '{print $3}' | cut -f1 -d '/')
+  partitionSize=$(/bin/df -k . | tail -1 | awk '{print $3}' | cut -f1 -d '/')
+
+  partitionSizeMB=$(echo "${partitionSize} / (1024 * 1024)" | bc)
   
   printDebug "Package Size: ${packageSize} MB"
-  printDebug "Partition Size: ${partitionSize} MB"
+  printDebug "Partition Size: ${partitionSizeMB} MB"
 
-  if [ 1 -eq "$(echo "${packageSize} > ${partitionSize}" | bc)" ]; then
+  if [ 1 -eq "$(echo "${packageSize} > ${partitionSizeMB}" | bc)" ]; then
     printError "Not enough space in partition."
   fi
   printInfo "Enough space to install ${package}. Proceeding installation."


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
This PR aims to fix the error message when '-m' option is not available in '/bin/df' by running with '-k' option and then manually converting to MB size.

## Related Issues

- Related Issue #893 
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
