### PR TITLE
Resolve issue with size calculation

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -398,9 +398,6 @@ handlePackageInstall()
     location="zopen package cache"
   fi
 
-  # Check partition size before download package
-  checkAvailableSize ${name} ${size}
-
   # Download the metadata json file
   if ! runAndLog "curlCmd -L '${metadataJSONURL}' -o '${metadataFile}'" ${redirectToDevNull}; then
     printError "Could not download from ${metadataJSONURL}. Correct any errors and potentially retry."
@@ -415,12 +412,13 @@ handlePackageInstall()
       redirectToDevNull="2>/dev/null"
     fi
 
+    # Check partition size before download package spinner starts
+    checkAvailableSize "${name}" "${size}" "Checking available size to download ${package}."
     progressHandler "network" "- Download complete." &
     ph=$!
     killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"
-    
-    checkAvailableSize ${name} ${size}
+        
     if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
       printError "Could not download from ${downloadURL}. Correct any errors and potentially retry."
       continue

--- a/include/common.sh
+++ b/include/common.sh
@@ -1335,20 +1335,19 @@ checkAvailableSize()
 { 
   
   package="$1"
+  packageSize="$2"
   printInfo "Checking available size to install ${package}."
 
-  packageSize=$(echo "scale=2; $2 / (1024 * 1024)" | bc)
+  printDebug "Package Size: ${packageSize} bytes"
+  packageSize=$(echo "scale=2; ${packageSize} / 1024" | bc)
+  printDebug "Package Size: ${packageSize} k"
   partitionSize=$(/bin/df -k . | tail -1 | awk '{print $3}' | cut -f1 -d '/')
-
-  partitionSizeMB=$(echo "${partitionSize} / (1024 * 1024)" | bc)
+  printDebug "Partition Size: ${partitionSize}k [free on '$(pwd -P)']"
   
-  printDebug "Package Size: ${packageSize} MB"
-  printDebug "Partition Size: ${partitionSizeMB} MB"
-
-  if [ 1 -eq "$(echo "${packageSize} > ${partitionSizeMB}" | bc)" ]; then
+  if [ 1 -eq "$(echo "${packageSize} > ${partitionSize}" | bc)" ]; then
     printError "Not enough space in partition."
   fi
-  printInfo "Enough space to install ${package}. Proceeding installation."
+  printInfo "- Enough space to install ${package}. Proceeding installation."
   return 0
 }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
The logic to calculate free space fails completely if there is less than around 1Gb of space on the file system and will be off in other cases.  

## Related Issues

- Related Issue #
- Closes #914 

## [optional] Are there any post-deployment tasks or follow-up actions required?
