### PR TITLE
Remove temporary gpg files after successful verification

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -24,7 +24,7 @@ checkWritable
 startGPGAgent()
 {
      printInfo "Starting gpg-agent..."
-     gpg-agent --daemon
+     gpg-agent --daemon --disable-scdaemon
      # Wait a moment to ensure the gpg-agent has time to start
      sleep 2
      # Check to confirm if gpg-agent started successfully
@@ -33,6 +33,13 @@ startGPGAgent()
      else
         printWarning "Failed to start the gpg-agent. Reinstall or upgrade GPG using \"zopen install --reinstall gpg -y\" or \"zopen upgrade gpg -y\" command."
      fi
+}
+
+gpgCleanup() {
+  printInfo "Cleaning up $SIGNATURE_FILE, $PUBLIC_KEY_FILE and $TMP_GPG_DIR"
+  [ -e "$SIGNATURE_FILE" ] && rm -f "$SIGNATURE_FILE"
+  [ -e "$PUBLIC_KEY_FILE" ] && rm -f "$PUBLIC_KEY_FILE"
+  [ -d "$TMP_GPG_DIR" ] && rm -rf "$TMP_GPG_DIR"
 }
 
 verifySignatureOfPax()
@@ -56,8 +63,8 @@ verifySignatureOfPax()
   TMP_GPG_DIR="$zopen_tmp_dir/zopen_gpg_verify_$LOGNAME_$$"
   mkdir -p "$TMP_GPG_DIR"
 
-  SIGNATURE_FILE="$zopen_tmp_dir/signedfile.$LOGNAME.$$.asc"
-  PUBLIC_KEY_FILE="$zopen_tmp_dir/scriptpubkey.$LOGNAME.$$.asc"
+  SIGNATURE_FILE="$zopen_tmp_dir/zopen_signedfile.$LOGNAME.$$.asc"
+  PUBLIC_KEY_FILE="$zopen_tmp_dir/zopen_scriptpubkey.$LOGNAME.$$.asc"
   printf "%b" "$SIGNATURE" | tr -d '"'  > "$SIGNATURE_FILE"
   printf "%b" "$PUBLIC_KEY" | tr -d '"'  > "$PUBLIC_KEY_FILE"
 
@@ -66,7 +73,7 @@ verifySignatureOfPax()
   printVerbose "Importing public key..."
   [ -f "$PUBLIC_KEY_FILE" ] && gpg --no-default-keyring --keyring "$TMP_GPG_DIR/pubring.kbx" --batch --yes --import "$PUBLIC_KEY_FILE"
   if [ $? -ne 0 ]; then
-      [ -e "${TMP_GPG_DIR}" ] && rm -rf "$TMP_GPG_DIR"
+      gpgCleanup
       printError "Importing public key failed. Verification aborted."
   fi
 
@@ -74,30 +81,30 @@ verifySignatureOfPax()
   printVerbose "Checking if public key is imported..."
   gpg --no-default-keyring --keyring "$TMP_GPG_DIR/pubring.kbx" --list-keys
   if [ $? -ne 0 ]; then
-      [ -e "${TMP_GPG_DIR}" ] && rm -rf "$TMP_GPG_DIR"
+      gpgCleanup
       printError "No public key found. Verification aborted."
   fi
 
   # Verify the signature
   printInfo "Verifying the gpg signature..."
   if [ -f "$SIGNATURE_FILE" ]; then
-	gpg_output=$(gpg --no-default-keyring --keyring "$TMP_GPG_DIR/pubring.kbx" --verify "$SIGNATURE_FILE" "$FILE_TO_VERIFY" 2>&1)
-        if echo "$gpg_output" | grep -q "Good signature from"; then
-           printInfo "${NC}${GREEN}Signature verified successfully: ${name}${NC}"
-           return 0
-        else
-           [ -e "${TMP_GPG_DIR}" ] && rm -rf "$TMP_GPG_DIR"
-           printError "Verification failed. Error is: $gpg_output"
-        fi
-   else
-        printError "Signature file does not exist."
+    gpg_output=$(gpg --no-default-keyring --keyring "$TMP_GPG_DIR/pubring.kbx" --verify "$SIGNATURE_FILE" "$FILE_TO_VERIFY" 2>&1)
+    if echo "$gpg_output" | grep -q "Good signature from"; then
+      gpgCleanup
+      printInfo "${NC}${GREEN}Signature verified successfully: ${name}${NC}"
+      return 0
+    else
+      gpgCleanup
+      printError "Verification failed. Error is: $gpg_output"
+    fi
+  else
+      gpgCleanup
+      printError "Signature file does not exist."
   fi
   
+  # It should not enter here, but add the cleanup just in case
+  gpgCleanup
   printInfo "GPG signature verified."
-  # Clean up the temporary directory/files
-  [ -e "${SIGNATURE_FILE}" ] && rm -f "${SIGNATURE_FILE}"
-  [ -e "${PUBLIC_KEY_FILE}" ] && rm -f "${PUBLIC_KEY_FILE}"
-  [ -d "${TMP_GPG_DIR}" ] && rm -rf "${TMP_GPG_DIR}"
 }
 
 printSyntax()


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
After a successful verification, due to the return 0 in https://github.com/zopencommunity/meta/compare/gpg_tmp_file_removal?expand=1#diff-c43bdd799ba8da6fcee24cd51eb2283d29922a616b6174ecdf43b458fc0a155cL87, files were not being cleaned up. Also, I was getting an scdaemon issue on plpsc so I have disabled that since it's not needed.
I also added a prefix of `zopen_` to the public and signature files.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
