### PR TITLE
Avoid forcing HTTP/1.0 on curl requests

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1068,12 +1068,12 @@ downloadTarBall()
     #
     curlCmd -I "${ZOPEN_URL}" > /dev/null 2>&1
 
-    if ! curlCmd -L -0 -o "${tarballz}" "${ZOPEN_URL}"; then
+    if ! curlCmd -L -o "${tarballz}" "${ZOPEN_URL}"; then
       if [ -f "${tarballz}" ] && [ $(wc -c "${tarballz}" | awk '{print $1}') -lt 1024 ]; then
         cat "${tarballz}" > /dev/null
       else
         printError "Re-try curl for diagnostics"
-        curlCmd -L -0 -o /dev/null "${ZOPEN_URL}"
+        curlCmd -L -o /dev/null "${ZOPEN_URL}"
       fi
       printError "Unable to download ${tarballz} from ${ZOPEN_URL}"
     fi


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
Some servers have deprecated support for HTTP/1.0 and no longer accept requests using this protocol. As a result, the -0 option in our zopen build code, which forces HTTP/1.0, is causing issues with certain requests. This PR removes the -0 flag to ensure compatibility with modern servers.

```
HTTP/1.1 200 OK
date: Mon, 20 Jan 2025 02:36:45 GMT
referrer-policy: strict-origin
strict-transport-security: max-age=63072000;includeSubDomains;preload
content-security-policy: img-src 'self' data:;font-src 'none'
x-frame-options: sameorigin
upgrade: h2,h2c
connection: Upgrade
last-modified: Wed, 15 Jan 2025 20:52:53 GMT
accept-ranges: bytes
content-length: 1172739
content-type: application/gzip
permissions-policy: interest-cohort=()

[ITODORO@ZOSCAN2B ~/projects/meta]$ curl -0 -I https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz
HTTP/1.0 403 Forbidden
cache-control: no-cache
content-type: text/html
```

## Related Issues

- Related Issue #
- Closes #
- Affects Rsyncport

## [optional] Are there any post-deployment tasks or follow-up actions required?
