### PR TITLE
Zopen build changes - new phase, zip processing and .jar file typing

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -909,8 +909,8 @@ tagBinaryFiles()
 #
 tagTree()
 {
-  dir="$1"
-  absdir=$(cd ${dir} && echo "${PWD}")
+  dirtotag="$1"
+  absdir=$(cd ${dirtotag} && echo "${PWD}")
   tagBinaryFiles "${absdir}"
 }
 

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1033,6 +1033,7 @@ extractTarBall()
 *.gmo binary
 *.po binary
 *.der binary
+*.jar binary
 " ".gitattributes"; then
       printError "Unable to create .gitattributes for tarball"
     fi

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1113,6 +1113,7 @@ applyPatches()
     tarballz=$(basename "${ZOPEN_URL}")
     root_loc=${tarballz%%.tar.*}
     root_loc=${root_loc%%.tgz}
+    root_loc=${root_loc%%.zip}
     code_dir="${ZOPEN_ROOT}/${root_loc}"
   else
     gitname=$(basename "${ZOPEN_URL}")

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2084,6 +2084,9 @@ resolveCommands()
     *cmake*)
       export ZOPEN_INSTALL_CMD="\"${ZOPEN_INSTALL}\" ${ZOPEN_INSTALL_OPTS}"
       ;;
+    skip)
+      export ZOPEN_INSTALL_CMD="\"${ZOPEN_INSTALL}\" ${ZOPEN_INSTALL_OPTS}"
+      ;;
     *)
       export ZOPEN_INSTALL_CMD="\"${ZOPEN_INSTALL}\" ${ZOPEN_INSTALL_OPTS} ${verboseOpts} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\""
       ;;

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -203,8 +203,8 @@ Optional:
                                     function is appended to install_test.sh
                                     script.
   zopen_install_caveats             This function is run post install. All stdout 
-                                    messages are captured and added to the metadata.json
-                                    as installation caveats.
+                                    messages are captured and added to the 
+                                    metadata.json as installation caveats.
   zopen_append_to_zoslib_env        This function runs as part of generation of
                                     the C function zoslib_env_hook, which can
                                     be used to set environment variables before
@@ -213,6 +213,8 @@ Optional:
                                     and patched but before the code is built.
   zopen_post_buildenv               This function runs after the 'buildenv' is
                                     processed.
+  zopen_post_extract                This function runs when an archive containing
+                                    the source to build has been uncompressed.
   zopen_post_install                This function runs after the 'install' step
                                     of the build is run.
   zopen_pre_build                   This function runs before the 'make' step
@@ -988,6 +990,12 @@ extractTarBall()
     if [ $? -gt 1 ]; then
       printError "unzip failed for ${tarballz}."
       echo "${out}" >&2
+    fi
+  fi
+  if command -V "zopen_post_extract" > /dev/null 2>&1; then
+    printVerbose "Running zopen_post_extract"
+    if ! "zopen_post_extract"  "${dir}"; then
+      printError "Error(s) running 'zopen_post_extract' from buildenv"
     fi
   fi
   rm -f "${tarballz}"


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
Add an additional phase to the zopen build processing, zopen_post_extract that runs after a compressed archivee has been expanded.  This allows for manipulation of the files [such as chtag'ing or moving/copying] prior to applying a patch.
This PR also contains: a change to add .jar as a file type to the .gitattrributes; correctly process zip files when calculating locations; a bug fix to prevent global variable shadowing; prevent adding additional paramters to the install command line when the configure phase was actually skipped. 

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
