### PR TITLE
Pass recursive submodule option to checkout command

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -944,11 +944,11 @@ gitClone()
       printError "Unable to clone ${gitname} from ${ZOPEN_URL}"
     fi
     if [ -n "${ZOPEN_GIT_BRANCH}" ]; then
-      if ! git -C "${dir}" checkout "${ZOPEN_GIT_BRANCH}" > /dev/null; then
+      if ! git -C "${dir}" checkout "${ZOPEN_GIT_BRANCH}" ${gitOptions} > /dev/null; then
         printError"Unable to checkout ${ZOPEN_URL} branch ${ZOPEN_GIT_BRANCH}"
       fi
     elif [ -n "${ZOPEN_GIT_TAG}" ]; then
-      if ! git -C "${dir}" checkout tags/"${ZOPEN_GIT_TAG}" -b "${ZOPEN_GIT_TAG}" > /dev/null; then
+      if ! git -C "${dir}" checkout tags/"${ZOPEN_GIT_TAG}" -b "${ZOPEN_GIT_TAG}" ${gitOptions} > /dev/null; then
         printError"Unable to checkout ${ZOPEN_URL} tag ${ZOPEN_GIT_TAG}"
       fi
     fi


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
Pass recursive submodule option to git checkout command as well. 
Fixes the issue where patches were not applying when the recursive submodule option was enabled.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
