### PR TITLE
changelog & release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ tools/src/hwthic.h
 # VSCode settings
 .vscode
 
+# IntelliJ IDEA settings
+.idea
+meta.iml
+
 # Generated files from md2man tooling
 
 docs/zopen/man1/zopen*.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,39 @@
 # Changelog
+## February 2025 🚧
+### 🔍 Other Changes
+- Pass recursive submodule option to checkout command ([#966](https://github.com/zopencommunity/meta/pull/966))
+- Provide a fuller template for buildenv ([#964](https://github.com/zopencommunity/meta/pull/964))
+- fix: typos in documentation files ([#962](https://github.com/zopencommunity/meta/pull/962))
+- Zopen build changes - new phase, zip processing and .jar file typing ([#965](https://github.com/zopencommunity/meta/pull/965))
+
+## January 2025
+### 📚 Documentation
+- Docs: adding currency status page ([#955](https://github.com/zopencommunity/meta/pull/955))
+- Update Porting.md - add vim info ([#932](https://github.com/zopencommunity/meta/pull/932))
+- Update workshop.md ([8218ce5](https://github.com/zopencommunity/meta/commit/8218ce50c922195c8a00bd0ea9e08a37ad5c360a))
+
+### 🔍 Other Changes
+- Modify startGPGAgent to test for existing socket ([#947](https://github.com/zopencommunity/meta/pull/947))
+- Avoid forcing HTTP/1.0 on curl requests ([#945](https://github.com/zopencommunity/meta/pull/945))
+- Set clang as the default build compiler ([#943](https://github.com/zopencommunity/meta/pull/943))
+- Adds `zopen info` command to display detailed information about a package ([#941](https://github.com/zopencommunity/meta/pull/941))
+- Initial upload of CHANGELOG ([#935](https://github.com/zopencommunity/meta/pull/935))
+- Remove temporary gpg files after successful verification + message updates ([#940](https://github.com/zopencommunity/meta/pull/940))
+- make video scale to fit ([#937](https://github.com/zopencommunity/meta/pull/937))
+- Update build_and_test.yml - Location response is now lowercase'd to location ([928524a](https://github.com/zopencommunity/meta/commit/928524a88d440ca953e7205bc61aaede80866c1b))
+
 ## December 2024
-### ✨ Features
+### 🔍 Other Changes
+- Update usage.zopen.community urls ([728d8ef](https://github.com/zopencommunity/meta/commit/728d8efa4d9716ded35dc4674ebc8a437d89ee3d))
 - Enhance zopen generate to create default main branch and add new contribution link ([#927](https://github.com/zopencommunity/meta/pull/927))
 - Add a prompt, plus improve messaging to inform the user about the zopen overriding behaviour on conflicting tools ([#926](https://github.com/zopencommunity/meta/pull/926))
 
-### 🔧 Maintenance
-- Update usage.zopen.community urls ([728d8ef](https://github.com/zopencommunity/meta/commit/728d8efa4d9716ded35dc4674ebc8a437d89ee3d))
-
 ## November 2024
-### ♻️ Refactoring
-- Several Website changes (adds categories, refactors scripts, and more) ([#898](https://github.com/zopencommunity/meta/pull/898))
-
 ### ✨ Features
+- Add scripts to monitor/restart if down, all of the cicd systems ([#923](https://github.com/zopencommunity/meta/pull/923))
 - Add recommended tools based on roles and update the TOC ([4629a54](https://github.com/zopencommunity/meta/commit/4629a54027f613e2057ea722d8981c3709e4ce54))
 - Add recommended tools based on roles and update the TOC ([a785890](https://github.com/zopencommunity/meta/commit/a78589035bb6e666085ad1e81afe6b85a930d4b0))
+- Several Website changes (adds categories, refactors scripts, and more) ([#898](https://github.com/zopencommunity/meta/pull/898))
 
 ### 🐛 Bug Fixes
 - Add issue template and workflow to create port repos in zopencommunity org ([#910](https://github.com/zopencommunity/meta/pull/910))
@@ -36,20 +56,17 @@
 - Update README.md ([b9d40db](https://github.com/zopencommunity/meta/commit/b9d40db29fd11ec159bf4ea31c49c8fdb3f1327e))
 - Update README.md ([dda04b1](https://github.com/zopencommunity/meta/commit/dda04b1ba45547374783ddd6986957a2b2e18c27))
 
-### 🔄 CI/CD
-- Add scripts to monitor/restart if down, all of the cicd systems ([#923](https://github.com/zopencommunity/meta/pull/923))
-- Update the cicd / usage urls to the new domain names ([#916](https://github.com/zopencommunity/meta/pull/916))
-
-### 🔍 Other Changes
-- Mark initialization files as IBM-1047 ([#888](https://github.com/zopencommunity/meta/pull/888))
-- Start gpg-agent for verification of signatures ([#908](https://github.com/zopencommunity/meta/pull/908))
-- Change commit user name ([#863](https://github.com/zopencommunity/meta/pull/863))
-- Invalid option -m passed to df during installs ([#909](https://github.com/zopencommunity/meta/pull/909))
-
 ### 🔧 Maintenance
 - Reinstante the correct update to link to new repo ([#920](https://github.com/zopencommunity/meta/pull/920))
 - Update getting z/OS access link ([5f3bc7d](https://github.com/zopencommunity/meta/commit/5f3bc7d3d95db76e0c1cee9fba8d0af4bf5b1339))
 - Update website ([09e9152](https://github.com/zopencommunity/meta/commit/09e91520352194d66585eeecaa4b809200f355f0))
+
+### 🔍 Other Changes
+- Mark initialization files as IBM-1047 ([#888](https://github.com/zopencommunity/meta/pull/888))
+- Update the cicd / usage urls to the new domain names ([#916](https://github.com/zopencommunity/meta/pull/916))
+- Start gpg-agent for verification of signatures ([#908](https://github.com/zopencommunity/meta/pull/908))
+- Change commit user name ([#863](https://github.com/zopencommunity/meta/pull/863))
+- Invalid option -m passed to df during installs ([#909](https://github.com/zopencommunity/meta/pull/909))
 
 ## October 2024
 ### ✨ Features
@@ -74,18 +91,6 @@
 - Do not print an error until we activate gpg in the build process ([9b9316e](https://github.com/zopencommunity/meta/commit/9b9316eb24d54235069412bc2e074d27b970ef12))
 - Add issue templates and automatic labeling ([#861](https://github.com/zopencommunity/meta/pull/861))
 
-### 📚 Documentation
-- Update QuickStart Guide. Make sidebar pages collapsed by default ([#880](https://github.com/zopencommunity/meta/pull/880))
-- Update logo in docs ([2574eb9](https://github.com/zopencommunity/meta/commit/2574eb9989ea3696fad3ab9895fc6221f3268faa))
-
-### 🔄 CI/CD
-- Allow specification of specific patch directory ([#890](https://github.com/zopencommunity/meta/pull/890))
-
-### 🔍 Other Changes
-- Avoid gpg temporary files colliding ([#891](https://github.com/zopencommunity/meta/pull/891))
-- zopen init changes ([#876](https://github.com/zopencommunity/meta/pull/876))
-- GPG - sign & verify pax files ([#852](https://github.com/zopencommunity/meta/pull/852))
-
 ### 🔧 Maintenance
 - Update zopen-init ([#899](https://github.com/zopencommunity/meta/pull/899))
 - Update tool_categories.txt ([6ed7da8](https://github.com/zopencommunity/meta/commit/6ed7da8d94590ef9c095bbfef09fdc4b95e57c21))
@@ -93,19 +98,23 @@
 - Update build.groovy ([#883](https://github.com/zopencommunity/meta/pull/883))
 - Update create_cve_json.py ([#856](https://github.com/zopencommunity/meta/pull/856))
 
+### 🔍 Other Changes
+- Avoid gpg temporary files colliding ([#891](https://github.com/zopencommunity/meta/pull/891))
+- Allow specification of specific patch directory ([#890](https://github.com/zopencommunity/meta/pull/890))
+- Update QuickStart Guide. Make sidebar pages collapsed by default ([#880](https://github.com/zopencommunity/meta/pull/880))
+- Update logo in docs ([2574eb9](https://github.com/zopencommunity/meta/commit/2574eb9989ea3696fad3ab9895fc6221f3268faa))
+- zopen init changes ([#876](https://github.com/zopencommunity/meta/pull/876))
+- GPG - sign & verify pax files ([#852](https://github.com/zopencommunity/meta/pull/852))
+
 ## September 2024
-### ✨ Features
+### 🔍 Other Changes
+- Rename z/OS Open Tools to zopen community (to be merged on Sept. 20) ([#862](https://github.com/zopencommunity/meta/pull/862))
 - add `skip` option to ZOPEN_COMP ([#858](https://github.com/zopencommunity/meta/pull/858))
 - Adding PR template ([#841](https://github.com/zopencommunity/meta/pull/841))
 
-### 🔍 Other Changes
-- Rename z/OS Open Tools to zopen community (to be merged on Sept. 20) ([#862](https://github.com/zopencommunity/meta/pull/862))
-
 ## August 2024
-### ✨ Features
+### 🔍 Other Changes
 - Add zopen build --instrument option to enable code instrumentation ([#851](https://github.com/zopencommunity/meta/pull/851))
-
-### 🐛 Bug Fixes
 - Re-org zopen-init code to avoid jq errors ([#850](https://github.com/zopencommunity/meta/pull/850))
 
 ## July 2024
@@ -114,19 +123,13 @@
 - Add options to zopen-audit for dealing with vulnerable packages ([#832](https://github.com/zopencommunity/meta/pull/832))
 - Adding best practices section ([#836](https://github.com/zopencommunity/meta/pull/836))
 
-### 🐛 Bug Fixes
-- Fix reg with is_collecting_stats ([8d281ac](https://github.com/zopencommunity/meta/commit/8d281ac644d6edda4d106f1000d31d8b442a5748))
-- Update QuickStart.md to address issue 720 ([#723](https://github.com/zopencommunity/meta/pull/723))
-- Zopen config bug fixes and key name policing ([#795](https://github.com/zopencommunity/meta/pull/795))
-
-### 💄 Style
-- Switch to new CVE json format ([#833](https://github.com/zopencommunity/meta/pull/833))
-
 ### 🔍 Other Changes
 - Enable file system setting for how /bin tools are overriden via zopen-init ([#828](https://github.com/zopencommunity/meta/pull/828))
+- Fix reg with is_collecting_stats ([8d281ac](https://github.com/zopencommunity/meta/commit/8d281ac644d6edda4d106f1000d31d8b442a5748))
+- Update QuickStart.md to address issue 720 ([#723](https://github.com/zopencommunity/meta/pull/723))
+- Switch to new CVE json format ([#833](https://github.com/zopencommunity/meta/pull/833))
+- Zopen config bug fixes and key name policing ([#795](https://github.com/zopencommunity/meta/pull/795))
 - Manual lists of CVEs to include and exclude ([#817](https://github.com/zopencommunity/meta/pull/817))
-
-### 🔧 Maintenance
 - Update instructions regarding new altbin dir ([#819](https://github.com/zopencommunity/meta/pull/819))
 
 ## June 2024
@@ -135,9 +138,6 @@
 - Add quick install similar to brew ([#811](https://github.com/zopencommunity/meta/pull/811))
 - Add view for newly released tools ([#741](https://github.com/zopencommunity/meta/pull/741))
 - Add zopen audit command to check installed packages for vulnerabilities ([#770](https://github.com/zopencommunity/meta/pull/770))
-
-### 🐛 Bug Fixes
-- Fix typos ([#813](https://github.com/zopencommunity/meta/pull/813))
 
 ### 📚 Documentation
 - Update blogs.md ([#786](https://github.com/zopencommunity/meta/pull/786))
@@ -148,6 +148,7 @@
 
 ### 🔍 Other Changes
 - Generate XML file for vulnerabilities RSS feed ([#794](https://github.com/zopencommunity/meta/pull/794))
+- Fix typos ([#813](https://github.com/zopencommunity/meta/pull/813))
 - Ensure true/false consistency for knv ([#787](https://github.com/zopencommunity/meta/pull/787))
 - Remove bashisms from zopen-audit script ([#784](https://github.com/zopencommunity/meta/pull/784))
 - Remove command trace & repush variable ([#782](https://github.com/zopencommunity/meta/pull/782))
@@ -156,31 +157,20 @@
 - Enable SSL for requests in create_cve_json script ([#773](https://github.com/zopencommunity/meta/pull/773))
 
 ## May 2024
-### ✨ Features
-- Add copyright and notices footer ([#759](https://github.com/zopencommunity/meta/pull/759))
-
-### 🐛 Bug Fixes
-- fix for comments and what is expected ([#764](https://github.com/zopencommunity/meta/pull/764))
-- Fix for zopen-build when zoslib_env is empty ([#763](https://github.com/zopencommunity/meta/pull/763))
-
-### 📚 Documentation
-- Update GitOnZOS.md ([#768](https://github.com/zopencommunity/meta/pull/768))
-
 ### 🔍 Other Changes
 - Script to generate json file of vulnerabilities in packages ([#765](https://github.com/zopencommunity/meta/pull/765))
+- Update GitOnZOS.md ([#768](https://github.com/zopencommunity/meta/pull/768))
+- fix for comments and what is expected ([#764](https://github.com/zopencommunity/meta/pull/764))
+- Fix for zopen-build when zoslib_env is empty ([#763](https://github.com/zopencommunity/meta/pull/763))
 - Remove escaped quotes in config ([#762](https://github.com/zopencommunity/meta/pull/762))
+- Add copyright and notices footer ([#759](https://github.com/zopencommunity/meta/pull/759))
 
 ## April 2024
-### 💄 Style
-- Add iden information to executables ([#750](https://github.com/zopencommunity/meta/pull/750))
-
 ### 🔍 Other Changes
 - Only generate zoslib hooks if CC is set ([#754](https://github.com/zopencommunity/meta/pull/754))
+- Add iden information to executables ([#750](https://github.com/zopencommunity/meta/pull/750))
 
 ## March 2024
-### ✨ Features
-- Added some info about curl ([#730](https://github.com/zopencommunity/meta/pull/730))
-
 ### 📚 Documentation
 - doc: the command zopen search is not valid ([#747](https://github.com/zopencommunity/meta/pull/747))
 - Simplify the meta README ([#744](https://github.com/zopencommunity/meta/pull/744))
@@ -189,16 +179,13 @@
 - Update VimOnZOS.md to remove old package manager workflow ([#724](https://github.com/zopencommunity/meta/pull/724))
 - Update FAQ.md with statement on support ([#721](https://github.com/zopencommunity/meta/pull/721))
 
-### 🔄 CI/CD
-- Add a blurb about github actions and rename Pipeline to Testing ([#568](https://github.com/zopencommunity/meta/pull/568))
-
 ### 🔍 Other Changes
+- Added some info about curl ([#730](https://github.com/zopencommunity/meta/pull/730))
 - Set GIT UTF8 CCSID to 819 for zopen builds ([#736](https://github.com/zopencommunity/meta/pull/736))
 - Embed usage statistics in Analytics page ([#725](https://github.com/zopencommunity/meta/pull/725))
-- workshop manual ([#668](https://github.com/zopencommunity/meta/pull/668))
-
-### 🔧 Maintenance
+- Add a blurb about github actions and rename Pipeline to Testing ([#568](https://github.com/zopencommunity/meta/pull/568))
 - Update version to 0.8.2 ([#716](https://github.com/zopencommunity/meta/pull/716))
+- workshop manual ([#668](https://github.com/zopencommunity/meta/pull/668))
 
 ## February 2024
 ### ✨ Features
@@ -226,10 +213,8 @@
 - Reorder doc updates ([c5a775a](https://github.com/zopencommunity/meta/commit/c5a775a2ced5a127e0d014c7cad5590a6bf37bef))
 
 ### 🔍 Other Changes
-- Create a CODEOWNERS file as part of zopen generate ([#678](https://github.com/zopencommunity/meta/pull/678))
-
-### 🔧 Maintenance
 - Update zopen-generate ([#709](https://github.com/zopencommunity/meta/pull/709))
+- Create a CODEOWNERS file as part of zopen generate ([#678](https://github.com/zopencommunity/meta/pull/678))
 
 ## January 2024
 ### ✨ Features
@@ -240,68 +225,59 @@
 ### 🐛 Bug Fixes
 - fix zopen-promote help so that it can be properly converted to man pages ([#666](https://github.com/zopencommunity/meta/pull/666))
 - Fix date to timestamp conversion ([#649](https://github.com/zopencommunity/meta/pull/649))
-- Fix README.md ([986430a](https://github.com/zopencommunity/meta/commit/986430ac7191d4158f4e3463218f4ee228d3725b))
 - Fix zopen-generate copy command + add stubs for bump in buildenv ([#648](https://github.com/zopencommunity/meta/pull/648))
-- fix erroneous ] in docupdate.sh ([#650](https://github.com/zopencommunity/meta/pull/650))
 
 ### 📚 Documentation
+- Fix README.md ([986430a](https://github.com/zopencommunity/meta/commit/986430ac7191d4158f4e3463218f4ee228d3725b))
 - Add details about Clang and Go compiler in porting pre-req doc ([#653](https://github.com/zopencommunity/meta/pull/653))
 - Correct the reference .md generation again ([#651](https://github.com/zopencommunity/meta/pull/651))
+- fix erroneous ] in docupdate.sh ([#650](https://github.com/zopencommunity/meta/pull/650))
 - Reference docs styling (#645) ([d3a87d6](https://github.com/zopencommunity/meta/commit/d3a87d6c8765abdec22a6be66d9b611c17c356ff))
 - Commit jenkins doc update cicd script ([0c4d18a](https://github.com/zopencommunity/meta/commit/0c4d18ac829dfd51435847e067032c3a62d21b7b))
 
 ### 🔍 Other Changes
 - Preserve steplib under ZOPEN_OLD_STEPLIB for compilers ([#659](https://github.com/zopencommunity/meta/pull/659))
+- Update release cache script to leverage release metadata.json ([#646](https://github.com/zopencommunity/meta/pull/646))
 - Server-side backend/Web UI for usage statistics ([#656](https://github.com/zopencommunity/meta/pull/656))
+- Update tool_categories.txt ([#647](https://github.com/zopencommunity/meta/pull/647))
 - Revert "Server-side backend/Web UI for usage statistics" ([3d5c2b4](https://github.com/zopencommunity/meta/commit/3d5c2b466ef4cadc7ca9ebfbaa42a3b4b09db11d))
 - Server-side backend/Web UI for usage statistics ([3c67e61](https://github.com/zopencommunity/meta/commit/3c67e611984096ae815de99e26d589046599c122))
 
-### 🔧 Maintenance
-- Update release cache script to leverage release metadata.json ([#646](https://github.com/zopencommunity/meta/pull/646))
-- Update tool_categories.txt ([#647](https://github.com/zopencommunity/meta/pull/647))
-
 ## December 2023
-### ♻️ Refactoring
-- Cleanup `zopen-install --help` output (#640) ([e06f992](https://github.com/zopencommunity/meta/commit/e06f992dc09edd911cc296576eda379799f14aa5))
-
 ### ✨ Features
 - Add copyright text (#642) ([a22f4c6](https://github.com/zopencommunity/meta/commit/a22f4c60cfdcb81f16aed9395e6518c5523b6b5d))
 - Implement some granular logic to --cache ([#627](https://github.com/zopencommunity/meta/pull/627))
 - Add 'zip' as a supported extension ([#632](https://github.com/zopencommunity/meta/pull/632))
 
 ### 🐛 Bug Fixes
-- Trivial typo in Migration.md ([#644](https://github.com/zopencommunity/meta/pull/644))
 - Fix markdown warnings, formatting,  spelling, and grammar ([#639](https://github.com/zopencommunity/meta/pull/639))
 - Message fixes ([#637](https://github.com/zopencommunity/meta/pull/637))
 - Fix test issue ([d309463](https://github.com/zopencommunity/meta/commit/d309463de670d2006b9fa54bc07aa806412855da))
 - added fix for findutilsport ([#575](https://github.com/zopencommunity/meta/pull/575))
-
-### 📚 Documentation
-- Docs: add a section for feedback ([#612](https://github.com/zopencommunity/meta/pull/612))
-
-### 🔍 Other Changes
-- Ensure z/OS standard sed is used in common.sh ([#638](https://github.com/zopencommunity/meta/pull/638))
-- metadata.json sizes should be in bytes, not 512-byte units ([#635](https://github.com/zopencommunity/meta/pull/635))
-- Improve package version changing ([#634](https://github.com/zopencommunity/meta/pull/634))
-- zopen-remove ([e1d32a0](https://github.com/zopencommunity/meta/commit/e1d32a0f23ec961a892bebf51e5ba95e998a7fd0))
-- Analytics - Collecting usage statistics for zopen ([#607](https://github.com/zopencommunity/meta/pull/607))
 
 ### 🔧 Maintenance
 - Update help text (#641) ([884d3e7](https://github.com/zopencommunity/meta/commit/884d3e741ac666d507e1a6bce76aeeada055ebd2))
 - Metaport43 zopen upgrade failure ([#626](https://github.com/zopencommunity/meta/pull/626))
 - Update version to 0.8.1 ([#609](https://github.com/zopencommunity/meta/pull/609))
 
-## November 2023
-### ♻️ Refactoring
-- Message cleanup ([#594](https://github.com/zopencommunity/meta/pull/594))
-- clean up help for manpages ([#557](https://github.com/zopencommunity/meta/pull/557))
+### 🔍 Other Changes
+- Trivial typo in Migration.md ([#644](https://github.com/zopencommunity/meta/pull/644))
+- Ensure z/OS standard sed is used in common.sh ([#638](https://github.com/zopencommunity/meta/pull/638))
+- Cleanup `zopen-install --help` output (#640) ([e06f992](https://github.com/zopencommunity/meta/commit/e06f992dc09edd911cc296576eda379799f14aa5))
+- metadata.json sizes should be in bytes, not 512-byte units ([#635](https://github.com/zopencommunity/meta/pull/635))
+- Improve package version changing ([#634](https://github.com/zopencommunity/meta/pull/634))
+- zopen-remove ([e1d32a0](https://github.com/zopencommunity/meta/commit/e1d32a0f23ec961a892bebf51e5ba95e998a7fd0))
+- Analytics - Collecting usage statistics for zopen ([#607](https://github.com/zopencommunity/meta/pull/607))
+- Docs: add a section for feedback ([#612](https://github.com/zopencommunity/meta/pull/612))
 
+## November 2023
 ### ✨ Features
 - Add zopen_pre_terminate hook ([#602](https://github.com/zopencommunity/meta/pull/602))
 - Re-init changes + add refresh option to refresh config file ([#595](https://github.com/zopencommunity/meta/pull/595))
 - Add in check for _BPXK_AUTOCVT and set if not set (fail if set to OFF) ([#597](https://github.com/zopencommunity/meta/pull/597))
 - zopen-build: Add an option to avoid installing runtime deps ([#587](https://github.com/zopencommunity/meta/pull/587))
 - Check if tty is available when getting columns + add other ways to obtain columns ([#560](https://github.com/zopencommunity/meta/pull/560))
+- Add bump and build_and_test yml files to data dir (used by zopen generate) ([#550](https://github.com/zopencommunity/meta/pull/550))
 - Convert properties.json to metadata.json and add more fields ([#460](https://github.com/zopencommunity/meta/pull/460))
 
 ### 🐛 Bug Fixes
@@ -322,36 +298,31 @@
 - Update _sidebar.md with link to zopen reference page ([#556](https://github.com/zopencommunity/meta/pull/556))
 
 ### 🔍 Other Changes
+- Use ETag vs Last modified to check if zopen_releases.json is updated ([#601](https://github.com/zopencommunity/meta/pull/601))
 - Improve the 'git reset' message when working with patches ([#600](https://github.com/zopencommunity/meta/pull/600))
+- Message cleanup ([#594](https://github.com/zopencommunity/meta/pull/594))
 - Redirect trap command stderr ([#591](https://github.com/zopencommunity/meta/pull/591))
 - Use alternate url for zopen_releases.json ([#582](https://github.com/zopencommunity/meta/pull/582))
 - Provide the total size up front when installing all tools (zopen install --all) ([#564](https://github.com/zopencommunity/meta/pull/564))
 - Move darkbackground logic ([#572](https://github.com/zopencommunity/meta/pull/572))
 - Use active symlink for LICENSE ([#574](https://github.com/zopencommunity/meta/pull/574))
+- clean up help for manpages ([#557](https://github.com/zopencommunity/meta/pull/557))
+- Update ansible to reflect new zopen ([#551](https://github.com/zopencommunity/meta/pull/551))
+- Update common.sh to allow for a "light mode" ([#543](https://github.com/zopencommunity/meta/pull/543))
 - Improve man and html page rendering ([#549](https://github.com/zopencommunity/meta/pull/549))
 - Tag and encode .env as IBM-1047 ([#548](https://github.com/zopencommunity/meta/pull/548))
 
-### 🔧 Maintenance
-- Use ETag vs Last modified to check if zopen_releases.json is updated ([#601](https://github.com/zopencommunity/meta/pull/601))
-- Update ansible to reflect new zopen ([#551](https://github.com/zopencommunity/meta/pull/551))
-- Update common.sh to allow for a "light mode" ([#543](https://github.com/zopencommunity/meta/pull/543))
-
-### 🧪 Testing
-- Add bump and build_and_test yml files to data dir (used by zopen generate) ([#550](https://github.com/zopencommunity/meta/pull/550))
-
 ## October 2023
-### ♻️ Refactoring
-- Rework cleanup logic ([#542](https://github.com/zopencommunity/meta/pull/542))
-- clean up options and put into sections ([#509](https://github.com/zopencommunity/meta/pull/509))
-- Add in logic to only run cleanup ([#494](https://github.com/zopencommunity/meta/pull/494))
-
-### ⚡️ Performance
-- Simplify zopen-config for better performance ([#507](https://github.com/zopencommunity/meta/pull/507))
-
 ### ✨ Features
 - Add a table to report download count for each project, sorted by projects with the highest downloads ([#546](https://github.com/zopencommunity/meta/pull/546))
+- Add reuseable github action workflow for testing ports ([#484](https://github.com/zopencommunity/meta/pull/484))
+- Add zoslib as an implicit dep ([#524](https://github.com/zopencommunity/meta/pull/524))
 - Add references in zopen to other commands ([#536](https://github.com/zopencommunity/meta/pull/536))
+- Do not add curl path to PATH when updating dependencies ([#532](https://github.com/zopencommunity/meta/pull/532))
+- remove partially implemented verbs - add back in when tested ([#519](https://github.com/zopencommunity/meta/pull/519))
 - Add a zopen pre-configure hook, needed by nginx ([#506](https://github.com/zopencommunity/meta/pull/506))
+- Add logic to handle test harness ([#497](https://github.com/zopencommunity/meta/pull/497))
+- Add in logic to only run cleanup ([#494](https://github.com/zopencommunity/meta/pull/494))
 - Add '}' to variable encapsulation ([#490](https://github.com/zopencommunity/meta/pull/490))
 - Add Haritha as a codeowner ([#481](https://github.com/zopencommunity/meta/pull/481))
 
@@ -370,44 +341,27 @@
 - Fix zopen-split-patch - fails with file argument ([#476](https://github.com/zopencommunity/meta/pull/476))
 - Fix matching of runtime dependencies in release cache ([#474](https://github.com/zopencommunity/meta/pull/474))
 
-### 📚 Documentation
-- Update developing.md ([#504](https://github.com/zopencommunity/meta/pull/504))
-- Update README for 'using' info ([#496](https://github.com/zopencommunity/meta/pull/496))
-
-### 🔄 CI/CD
-- Improved Explicit Upgrade Message ([#539](https://github.com/zopencommunity/meta/pull/539))
-- Add reuseable github action workflow for testing ports ([#484](https://github.com/zopencommunity/meta/pull/484))
-- Add zoslib as an implicit dep ([#524](https://github.com/zopencommunity/meta/pull/524))
-- Do not add curl path to PATH when updating dependencies ([#532](https://github.com/zopencommunity/meta/pull/532))
-
 ### 🔍 Other Changes
+- Improved Explicit Upgrade Message ([#539](https://github.com/zopencommunity/meta/pull/539))
+- Rework cleanup logic ([#542](https://github.com/zopencommunity/meta/pull/542))
+- Updates for quickstart ([#510](https://github.com/zopencommunity/meta/pull/510))
 - set non-zero rc when help2man fails to generate file ([#530](https://github.com/zopencommunity/meta/pull/530))
 - Increment release to 0.8.0 ([#525](https://github.com/zopencommunity/meta/pull/525))
 - Improve message as per #380 ([#518](https://github.com/zopencommunity/meta/pull/518))
+- Re-enable update-cacert ([#523](https://github.com/zopencommunity/meta/pull/523))
 - help2man wants executable name, not full-path ([#520](https://github.com/zopencommunity/meta/pull/520))
+- Update developing.md ([#504](https://github.com/zopencommunity/meta/pull/504))
+- clean up options and put into sections ([#509](https://github.com/zopencommunity/meta/pull/509))
 - force zopen_get_version to be required ([#512](https://github.com/zopencommunity/meta/pull/512))
 - Check if JSON cache is accessible ([#514](https://github.com/zopencommunity/meta/pull/514))
+- Simplify zopen-config for better performance ([#507](https://github.com/zopencommunity/meta/pull/507))
+- Update README for 'using' info ([#496](https://github.com/zopencommunity/meta/pull/496))
 - 500 urgent zopen clean u pkg too aggressive ([#502](https://github.com/zopencommunity/meta/pull/502))
 - provide --version for all and call zopen-version directly ([#488](https://github.com/zopencommunity/meta/pull/488))
 - 448 redux ([#475](https://github.com/zopencommunity/meta/pull/475))
-
-### 🔧 Maintenance
-- Updates for quickstart ([#510](https://github.com/zopencommunity/meta/pull/510))
-- Re-enable update-cacert ([#523](https://github.com/zopencommunity/meta/pull/523))
 - FAQ updates ([#480](https://github.com/zopencommunity/meta/pull/480))
 
-### 🧪 Testing
-- remove partially implemented verbs - add back in when tested ([#519](https://github.com/zopencommunity/meta/pull/519))
-- Add logic to handle test harness ([#497](https://github.com/zopencommunity/meta/pull/497))
-
 ## September 2023
-### ♻️ Refactoring
-- clean up options processing ([#461](https://github.com/zopencommunity/meta/pull/461))
-
-### ⚡️ Performance
-- restrict tools that perform an update to writable zopen tool chains ([#464](https://github.com/zopencommunity/meta/pull/464))
-- Optimize .env and .zopen-config processing ([#390](https://github.com/zopencommunity/meta/pull/390))
-
 ### ✨ Features
 - Add checks to publish.groovy script ([#467](https://github.com/zopencommunity/meta/pull/467))
 - Add a blurb on upgrading meta ([#439](https://github.com/zopencommunity/meta/pull/439))
@@ -457,8 +411,16 @@
 - Updates to CI build step to upgrade meta, clean cache ([#455](https://github.com/zopencommunity/meta/pull/455))
 - Update publish_oci.sh ([ccd779e](https://github.com/zopencommunity/meta/commit/ccd779eee0c89d8049534fc294df35657f0d0488))
 
+### 🔧 Maintenance
+- Update publish.groovy ([4feca6a](https://github.com/zopencommunity/meta/commit/4feca6a83f0c4350b94f3e4c8eefb47bb311e2f2))
+- Update zopen_releases.json ([735fd19](https://github.com/zopencommunity/meta/commit/735fd19ec8b78d09378dd073c096771ac65c7534))
+- Update action.yml ([#429](https://github.com/zopencommunity/meta/pull/429))
+- Update build.groovy ([0ef3dad](https://github.com/zopencommunity/meta/commit/0ef3dad78dd317b82bf2a84a8fdcde0c4adec00e))
+
 ### 🔍 Other Changes
 - Increase delay after github release is created ([#466](https://github.com/zopencommunity/meta/pull/466))
+- restrict tools that perform an update to writable zopen tool chains ([#464](https://github.com/zopencommunity/meta/pull/464))
+- clean up options processing ([#461](https://github.com/zopencommunity/meta/pull/461))
 - take another crack - move the version file ([#454](https://github.com/zopencommunity/meta/pull/454))
 - rename version file from .version to zopen-version ([#453](https://github.com/zopencommunity/meta/pull/453))
 - Use the ID zosopentoolsmain for user_name in the action ([#437](https://github.com/zopencommunity/meta/pull/437))
@@ -474,19 +436,15 @@
 - Use  <rootfs>usr/local/  as  base rather than ([#411](https://github.com/zopencommunity/meta/pull/411))
 - Pass thru custom curl parameters ([#407](https://github.com/zopencommunity/meta/pull/407))
 - Change the install location so as not to conflict with the default zopen install location. ([#399](https://github.com/zopencommunity/meta/pull/399))
+- Optimize .env and .zopen-config processing ([#390](https://github.com/zopencommunity/meta/pull/390))
 - Remove dot from zopen-config, so it's not hidden ([#384](https://github.com/zopencommunity/meta/pull/384))
 - Echo the pax location ([1074e15](https://github.com/zopencommunity/meta/commit/1074e15fd39755bbc112b44e2abce7a84da7c29b))
 - Merge Russell's zopen fork into main ([#376](https://github.com/zopencommunity/meta/pull/376))
 
-### 🔧 Maintenance
-- Update publish.groovy ([4feca6a](https://github.com/zopencommunity/meta/commit/4feca6a83f0c4350b94f3e4c8eefb47bb311e2f2))
-- Update zopen_releases.json ([735fd19](https://github.com/zopencommunity/meta/commit/735fd19ec8b78d09378dd073c096771ac65c7534))
-- Update action.yml ([#429](https://github.com/zopencommunity/meta/pull/429))
-- Update build.groovy ([0ef3dad](https://github.com/zopencommunity/meta/commit/0ef3dad78dd317b82bf2a84a8fdcde0c4adec00e))
-
 ## August 2023
 ### ✨ Features
 - Add Mike Fulton's script to split an consolidated git patch into individual patches for each file ([#368](https://github.com/zopencommunity/meta/pull/368))
+- Add logic to publish builds as OCI artifacts into the github container registry ([#364](https://github.com/zopencommunity/meta/pull/364))
 - Add zopen_pre_patch and support for cloning with submodules ([#363](https://github.com/zopencommunity/meta/pull/363))
 
 ### 🐛 Bug Fixes
@@ -500,9 +458,6 @@
 - docs page octocat link does not work ([#372](https://github.com/zopencommunity/meta/pull/372))
 - Update README.md ([#365](https://github.com/zopencommunity/meta/pull/365))
 
-### 🔄 CI/CD
-- Add logic to publish builds as OCI artifacts into the github container registry ([#364](https://github.com/zopencommunity/meta/pull/364))
-
 ### 🔍 Other Changes
 - Correct permissions ([e6b9907](https://github.com/zopencommunity/meta/commit/e6b99074f75bd5d3779faf2362686d2fca02bef4))
 - Set default BUILD_LINE to Stable ([9936c27](https://github.com/zopencommunity/meta/commit/9936c27b13e9df84432733ea0b4d7a9896345bf7))
@@ -510,14 +465,12 @@
 
 ## July 2023
 ### ✨ Features
+- Add support for dev and stable builds in Jenkins ([#360](https://github.com/zopencommunity/meta/pull/360))
 - Support for stable and dev line builds ([#353](https://github.com/zopencommunity/meta/pull/353))
 - Add a tool to cache all z/OS Open Tools releases ([#354](https://github.com/zopencommunity/meta/pull/354))
 
-### 🐛 Bug Fixes
+### 🔍 Other Changes
 - Add download url and fix removal of port suffix in JSON cache ([#356](https://github.com/zopencommunity/meta/pull/356))
-
-### 🔄 CI/CD
-- Add support for dev and stable builds in Jenkins ([#360](https://github.com/zopencommunity/meta/pull/360))
 
 ## June 2023
 ### ✨ Features
@@ -531,24 +484,21 @@
 - Fix external blog link ([3d9e23b](https://github.com/zopencommunity/meta/commit/3d9e23b935cb10c9001563b5b18430e2d057aa79))
 - Fix for tgz when applying patches ([9084d0f](https://github.com/zopencommunity/meta/commit/9084d0f80b8d3c378e84249d2f9dd66f9e52065e))
 
-### 📚 Documentation
-- Update _sidebar.md ([#331](https://github.com/zopencommunity/meta/pull/331))
-
-### 🔄 CI/CD
-- simple utility to compute build dependencies - tarball only ([#316](https://github.com/zopencommunity/meta/pull/316))
-- Refactor and offload most compiler logic to dependencies ([#282](https://github.com/zopencommunity/meta/pull/282))
-
 ### 🔍 Other Changes
 - Install zopen into the usual path rather than the current directory ([#348](https://github.com/zopencommunity/meta/pull/348))
 - Do not create a .depenvs if top level project is not installed ([#346](https://github.com/zopencommunity/meta/pull/346))
 - importenv enhancements ([#336](https://github.com/zopencommunity/meta/pull/336))
 - Modify zopen-build to generate the .depsenv rather than zopen-install ([#334](https://github.com/zopencommunity/meta/pull/334))
+- Update _sidebar.md ([#331](https://github.com/zopencommunity/meta/pull/331))
 - GPG article ([#317](https://github.com/zopencommunity/meta/pull/317))
+- simple utility to compute build dependencies - tarball only ([#316](https://github.com/zopencommunity/meta/pull/316))
 - simple tool to print out brew and z/os tool versions ([#315](https://github.com/zopencommunity/meta/pull/315))
+- Refactor and offload most compiler logic to dependencies ([#282](https://github.com/zopencommunity/meta/pull/282))
 
 ## May 2023
 ### ✨ Features
 - Add additional common solutions ([#313](https://github.com/zopencommunity/meta/pull/313))
+- zopen-generate: add polling in cicd.groovy ([#309](https://github.com/zopencommunity/meta/pull/309))
 - Add a ZOPEN_CHECK_MINIMAL and *_FOR_BUILD envars ([#294](https://github.com/zopencommunity/meta/pull/294))
 
 ### 🐛 Bug Fixes
@@ -556,26 +506,17 @@
 - Update stable tools and fix token bug in create_stable_releases.sh ([#291](https://github.com/zopencommunity/meta/pull/291))
 - Fix spelling ([#283](https://github.com/zopencommunity/meta/pull/283))
 
-### 📚 Documentation
-- Readme cleanup ([#305](https://github.com/zopencommunity/meta/pull/305))
-- docs: added hint for environment variable ([#289](https://github.com/zopencommunity/meta/pull/289))
-
-### 🔄 CI/CD
-- zopen-generate: add polling in cicd.groovy ([#309](https://github.com/zopencommunity/meta/pull/309))
-- Modify jenkins ip to new instance ([#303](https://github.com/zopencommunity/meta/pull/303))
-- CICD: Install python modules if not present in publish job ([#292](https://github.com/zopencommunity/meta/pull/292))
-
 ### 🔍 Other Changes
 - removed outdated comment ([#300](https://github.com/zopencommunity/meta/pull/300))
 - Initial ansible playbook for setting up a z/OS vpc instance ([#209](https://github.com/zopencommunity/meta/pull/209))
 - Allow an option to override default zopen type ([#299](https://github.com/zopencommunity/meta/pull/299))
+- Readme cleanup ([#305](https://github.com/zopencommunity/meta/pull/305))
+- Modify jenkins ip to new instance ([#303](https://github.com/zopencommunity/meta/pull/303))
+- CICD: Install python modules if not present in publish job ([#292](https://github.com/zopencommunity/meta/pull/292))
+- docs: added hint for environment variable ([#289](https://github.com/zopencommunity/meta/pull/289))
 - Create stable releases rather than boot releases ([#284](https://github.com/zopencommunity/meta/pull/284))
 
 ## April 2023
-### ♻️ Refactoring
-- Cleanup on a fresh build should remove configure/bootstrap success files ([#270](https://github.com/zopencommunity/meta/pull/270))
-- Clean up syntax help message ([#269](https://github.com/zopencommunity/meta/pull/269))
-
 ### ✨ Features
 - Add ZOPEN_TYPE=BARE for cases where the binaries already exist ([#277](https://github.com/zopencommunity/meta/pull/277))
 - Add instructions on how to set bash as your default shell ([#272](https://github.com/zopencommunity/meta/pull/272))
@@ -587,14 +528,14 @@
 - -Werror causes issues in the headers since they have warnings ([#260](https://github.com/zopencommunity/meta/pull/260))
 
 ### 🔍 Other Changes
+- Cleanup on a fresh build should remove configure/bootstrap success files ([#270](https://github.com/zopencommunity/meta/pull/270))
+- Clean up syntax help message ([#269](https://github.com/zopencommunity/meta/pull/269))
 - resolved conflict , raised new PR same as PR #242 under meta ([#261](https://github.com/zopencommunity/meta/pull/261))
 
 ## March 2023
-### ♻️ Refactoring
-- Retain Python path in PATH environment variable after cleanup ([#228](https://github.com/zopencommunity/meta/pull/228))
-- clean up zopen build 'zopen_init' function ([#219](https://github.com/zopencommunity/meta/pull/219))
-
 ### ✨ Features
+- Add expected total tests to zopen_check_results ([#254](https://github.com/zopencommunity/meta/pull/254))
+- Add CICD params to force build with clang, no promotion boolean, and release level ([#247](https://github.com/zopencommunity/meta/pull/247))
 - Add slack message color for successful builds ([#255](https://github.com/zopencommunity/meta/pull/255))
 - Add curl to the path when we run zopen install ([#225](https://github.com/zopencommunity/meta/pull/225))
 - Progress page: add Projects with most patches + allow ports to skip publishing if no pax found ([#207](https://github.com/zopencommunity/meta/pull/207))
@@ -606,39 +547,29 @@
 - Use tar -axf now that its issues are resolved ([#211](https://github.com/zopencommunity/meta/pull/211))
 - Ignore utime Invalid argument tar error ([#210](https://github.com/zopencommunity/meta/pull/210))
 
-### 📚 Documentation
-- add new guide on terminal config for non-US characters ([#259](https://github.com/zopencommunity/meta/pull/259))
-
-### 🔄 CI/CD
-- Add CICD params to force build with clang, no promotion boolean, and release level ([#247](https://github.com/zopencommunity/meta/pull/247))
-- Handle read-only files when replacing hardcoded install paths ([#234](https://github.com/zopencommunity/meta/pull/234))
-- Override global .gitattributes by specifying UTF-8 working tree encoding ([#227](https://github.com/zopencommunity/meta/pull/227))
-
 ### 🔍 Other Changes
+- add new guide on terminal config for non-US characters ([#259](https://github.com/zopencommunity/meta/pull/259))
 - Change installing to checking in header ([#251](https://github.com/zopencommunity/meta/pull/251))
 - Generate zoslib env hook ([#236](https://github.com/zopencommunity/meta/pull/236))
 - Ignore .vscode directory ([#246](https://github.com/zopencommunity/meta/pull/246))
 - Have 'git' generate a MANPATH entry ([#239](https://github.com/zopencommunity/meta/pull/239))
+- Handle read-only files when replacing hardcoded install paths ([#234](https://github.com/zopencommunity/meta/pull/234))
 - Move _TAG_REDIR_* envars before functions ([#229](https://github.com/zopencommunity/meta/pull/229))
+- Retain Python path in PATH environment variable after cleanup ([#228](https://github.com/zopencommunity/meta/pull/228))
+- Override global .gitattributes by specifying UTF-8 working tree encoding ([#227](https://github.com/zopencommunity/meta/pull/227))
+- Update boot list to include sed, grep and gawk. Also print out the boot list on help ([#223](https://github.com/zopencommunity/meta/pull/223))
 - changed the token reading var name ([#221](https://github.com/zopencommunity/meta/pull/221))
 - Use default PATH/MANPATH/LIBPATH/etc before zopen build for consistent results ([#204](https://github.com/zopencommunity/meta/pull/204))
+- clean up zopen build 'zopen_init' function ([#219](https://github.com/zopencommunity/meta/pull/219))
 - change links from short link to original long form ([#217](https://github.com/zopencommunity/meta/pull/217))
 
-### 🔧 Maintenance
-- Update boot list to include sed, grep and gawk. Also print out the boot list on help ([#223](https://github.com/zopencommunity/meta/pull/223))
-
-### 🧪 Testing
-- Add expected total tests to zopen_check_results ([#254](https://github.com/zopencommunity/meta/pull/254))
-
 ## February 2023
-### ♻️ Refactoring
-- Step 1 of deps parsing of optional operator and version, and cleanup of envars ([#151](https://github.com/zopencommunity/meta/pull/151))
-
 ### ✨ Features
 - Script to add branch protection to repos ([#200](https://github.com/zopencommunity/meta/pull/200))
 - Script to automatically add teams to all repos ([#197](https://github.com/zopencommunity/meta/pull/197))
 - Revert "add build timestamp" ([5c5debd](https://github.com/zopencommunity/meta/commit/5c5debd194ff61a01c8ae13ae0417cc590914789))
 - add build timestamp ([440d7b5](https://github.com/zopencommunity/meta/commit/440d7b5042153548caee5e3364720a5dee4ed14e))
+- Add support for installing runtime dependencies ([#160](https://github.com/zopencommunity/meta/pull/160))
 - Add support for $HOME/zopen as target location and running without _BPX_AUTOCVT set ([#150](https://github.com/zopencommunity/meta/pull/150))
 
 ### 🐛 Bug Fixes
@@ -666,28 +597,25 @@
 - cicd changes ([2da24ff](https://github.com/zopencommunity/meta/commit/2da24ff14a84dfe8f012025ed02c541e083a487b))
 - Use default install location in cicd ([#188](https://github.com/zopencommunity/meta/pull/188))
 - .env sourcing of dependencies + download-only option ([#170](https://github.com/zopencommunity/meta/pull/170))
-- Add support for installing runtime dependencies ([#160](https://github.com/zopencommunity/meta/pull/160))
 
 ### 🔍 Other Changes
 - Change one liner install command to work for /bin/sh as well as bash ([#199](https://github.com/zopencommunity/meta/pull/199))
 - Shorten the demo ([#193](https://github.com/zopencommunity/meta/pull/193))
+- Place test.status in a known location ([a505fa1](https://github.com/zopencommunity/meta/commit/a505fa1f27f9942fec3c39276db2dc678fa27bc7))
 - allow installs to be moveable ([#189](https://github.com/zopencommunity/meta/pull/189))
+- Update publish.groovy for new directory name ([#187](https://github.com/zopencommunity/meta/pull/187))
 - Redirect output from cd - and popd to /dev/null ([#185](https://github.com/zopencommunity/meta/pull/185))
 - Remove build timestamp in resulting directory for new and existing pax.Z packages ([#182](https://github.com/zopencommunity/meta/pull/182))
 - use pushd/popd when in bash ([#181](https://github.com/zopencommunity/meta/pull/181))
 - Various zopen-build Improvements ([#169](https://github.com/zopencommunity/meta/pull/169))
 - Do not replace hardcoded paths in binaries ([#165](https://github.com/zopencommunity/meta/pull/165))
-- Use /bin/iconv which converts EBCDIC ([#154](https://github.com/zopencommunity/meta/pull/154))
-
-### 🔧 Maintenance
-- Update publish.groovy for new directory name ([#187](https://github.com/zopencommunity/meta/pull/187))
+- Step 1 of deps parsing of optional operator and version, and cleanup of envars ([#151](https://github.com/zopencommunity/meta/pull/151))
 - Improve zopen update cacert ([#155](https://github.com/zopencommunity/meta/pull/155))
-
-### 🧪 Testing
-- Place test.status in a known location ([a505fa1](https://github.com/zopencommunity/meta/commit/a505fa1f27f9942fec3c39276db2dc678fa27bc7))
+- Use /bin/iconv which converts EBCDIC ([#154](https://github.com/zopencommunity/meta/pull/154))
 
 ## January 2023
 ### ✨ Features
+- Add git as an implicit dep since we use it to initialize the tar source dir as a git repo ([#149](https://github.com/zopencommunity/meta/pull/149))
 - Delete existing install directory before extracting + Address binary files in .gitattributes + Use default UTF-8 encoding ([#147](https://github.com/zopencommunity/meta/pull/147))
 - Add monitor_vpc.sh script ([#141](https://github.com/zopencommunity/meta/pull/141))
 - Add checks for safer setup ([#137](https://github.com/zopencommunity/meta/pull/137))
@@ -696,6 +624,7 @@
 - provide cacert support for metaport, git, curl ([#128](https://github.com/zopencommunity/meta/pull/128))
 - Add initial FAQ ([#109](https://github.com/zopencommunity/meta/pull/109))
 - Add .gitattributes ([9527784](https://github.com/zopencommunity/meta/commit/95277843cbba45742c8bb3b4fba6cdeca9352881))
+- Add the actual dependent projects in the table "Projects with the most dependencies" ([#106](https://github.com/zopencommunity/meta/pull/106))
 - addressed changes related to boottool - Enhanced the tool to retain t… ([#104](https://github.com/zopencommunity/meta/pull/104))
 - Add pre-req project links and license info ([#102](https://github.com/zopencommunity/meta/pull/102))
 
@@ -710,13 +639,6 @@
 - Fix merge conflicts ([64a951b](https://github.com/zopencommunity/meta/commit/64a951bfc5148942492696cb5284e2e717d910cf))
 - Fix permissions for bin/lib/zopen-build ([#133](https://github.com/zopencommunity/meta/pull/133))
 
-### 📚 Documentation
-- Various documentation updates ([#124](https://github.com/zopencommunity/meta/pull/124))
-
-### 🔄 CI/CD
-- Add git as an implicit dep since we use it to initialize the tar source dir as a git repo ([#149](https://github.com/zopencommunity/meta/pull/149))
-- Add the actual dependent projects in the table "Projects with the most dependencies" ([#106](https://github.com/zopencommunity/meta/pull/106))
-
 ### 🔍 Other Changes
 - Move setup.sh to end of .env so that you can use envars in setup.sh ([#144](https://github.com/zopencommunity/meta/pull/144))
 - Increase buffer size used for GitHub token. ([#139](https://github.com/zopencommunity/meta/pull/139))
@@ -724,12 +646,11 @@
 - Use /bin/echo to intrepret backslash escapes. Modern echo requires -e option ([#136](https://github.com/zopencommunity/meta/pull/136))
 - Move to open source tar in zopen build code ([#135](https://github.com/zopencommunity/meta/pull/135))
 - Merge pull request #127 from ZOSOpenTools/change_zopen_download ([794575c](https://github.com/zopencommunity/meta/commit/794575cbdc46e352b1c6d0fd3bd149f199b66a0e))
+- Various documentation updates ([#124](https://github.com/zopencommunity/meta/pull/124))
 - No need to clone meta since we're already in it ([3b8cc66](https://github.com/zopencommunity/meta/commit/3b8cc66b094d23873e43d6fc7b814221aedf08fa))
 - Avoid processing files in .env if there are no hardcoded paths + separate setup from environment variables ([#135](https://github.com/zopencommunity/meta/pull/135))
-- Don't let the ZOPEN_CHECK process become an orphaned process upon early exit ([#134](https://github.com/zopencommunity/meta/pull/134))
-
-### 🔧 Maintenance
 - Update all references to utils and change them to meta ([9c19fef](https://github.com/zopencommunity/meta/commit/9c19fefec154fd0ce4471445abbf5daea1b7a5ec))
+- Don't let the ZOPEN_CHECK process become an orphaned process upon early exit ([#134](https://github.com/zopencommunity/meta/pull/134))
 
 ## December 2022
 ### ✨ Features
@@ -748,44 +669,32 @@
 ### 🔍 Other Changes
 - Commit iD retaining for the boot-release created ([#91](https://github.com/zopencommunity/meta/pull/91))
 - Improve legibility of status bar chart ([#100](https://github.com/zopencommunity/meta/pull/100))
+- Create .zopen-config file with zopen-init, and also update zopen-build/download to depend on it ([#131](https://github.com/zopencommunity/meta/pull/131))
 - Remove colons from headings ([#90](https://github.com/zopencommunity/meta/pull/90))
 - Adjust directory permissions ([#96](https://github.com/zopencommunity/meta/pull/96))
 
-### 🔧 Maintenance
-- Create .zopen-config file with zopen-init, and also update zopen-build/download to depend on it ([#131](https://github.com/zopencommunity/meta/pull/131))
-
 ## November 2022
-### ✨ Features
-- add LDLIBS (used by openssl) + add .gitignore in zopen-generate ([#104](https://github.com/zopencommunity/meta/pull/104))
-- Support for tags in zopen download, update only if newer releases are found + more ([#97](https://github.com/zopencommunity/meta/pull/97))
-
 ### 🐛 Bug Fixes
 - Fix small typo on Getting Started page ([#88](https://github.com/zopencommunity/meta/pull/88))
 - force rebuild option (-f) + override log dir with ZOPEN_LOG_DIR + fix -DCPPFLAGS in configure opts ([#102](https://github.com/zopencommunity/meta/pull/102))
 - fix: correctly test for help flag ([#99](https://github.com/zopencommunity/meta/pull/99))
-
-### 💄 Style
-- Update getbinaries.py to get dependent project information ([9f3c7f8](https://github.com/zopencommunity/meta/commit/9f3c7f8d1a9e16d5d23987b87dd642eefba3e4dc))
 
 ### 📚 Documentation
 - Add initial docs on zoslib ([#83](https://github.com/zopencommunity/meta/pull/83))
 - Update docs for common problems ASCII open and FSUM msg ([#82](https://github.com/zopencommunity/meta/pull/82))
 - Update Pre-req.md ([#72](https://github.com/zopencommunity/meta/pull/72))
 
-### 🔄 CI/CD
-- Update cicd tool to report more status ([e69b95d](https://github.com/zopencommunity/meta/commit/e69b95da5cd2315896b0407dd23e9f0455638aee))
-- Update cicd/build.groovy to always update ([1b4cd9e](https://github.com/zopencommunity/meta/commit/1b4cd9e9d2ed03c2138c895140d525bef172c3e0))
-
 ### 🔍 Other Changes
+- update from origin ([#1](https://github.com/zopencommunity/meta/pull/1))
 - initial commit of boot tool ([#81](https://github.com/zopencommunity/meta/pull/81))
 - Getting started ([#70](https://github.com/zopencommunity/meta/pull/70))
-- mention rocket curl for consumers ([#69](https://github.com/zopencommunity/meta/pull/69))
-
-### 🔧 Maintenance
-- update from origin ([#1](https://github.com/zopencommunity/meta/pull/1))
-
-### 🧪 Testing
 - get latest releases instead of the first one ([ec8968f](https://github.com/zopencommunity/meta/commit/ec8968f01b1ea127477042348f28782249d44fb1))
+- Update getbinaries.py to get dependent project information ([9f3c7f8](https://github.com/zopencommunity/meta/commit/9f3c7f8d1a9e16d5d23987b87dd642eefba3e4dc))
+- Update cicd tool to report more status ([e69b95d](https://github.com/zopencommunity/meta/commit/e69b95da5cd2315896b0407dd23e9f0455638aee))
+- add LDLIBS (used by openssl) + add .gitignore in zopen-generate ([#104](https://github.com/zopencommunity/meta/pull/104))
+- mention rocket curl for consumers ([#69](https://github.com/zopencommunity/meta/pull/69))
+- Support for tags in zopen download, update only if newer releases are found + more ([#97](https://github.com/zopencommunity/meta/pull/97))
+- Update cicd/build.groovy to always update ([1b4cd9e](https://github.com/zopencommunity/meta/commit/1b4cd9e9d2ed03c2138c895140d525bef172c3e0))
 
 ## October 2022
 ### ✨ Features
@@ -794,6 +703,7 @@
 - zopen-generate: check for port in name + add .gitattributes ([8da7e53](https://github.com/zopencommunity/meta/commit/8da7e536bc33c298c9da5946431ff4eb97c3f591))
 - Add -qenum=int as a default compiler option ([#79](https://github.com/zopencommunity/meta/pull/79))
 - added clarification around the C/C++ build compiler ([#53](https://github.com/zopencommunity/meta/pull/53))
+- Adds support for specifying LIBS (needed to link with ZOSLIB) ([#76](https://github.com/zopencommunity/meta/pull/76))
 
 ### 🐛 Bug Fixes
 - Add CEE3728S to list of common issues ([#55](https://github.com/zopencommunity/meta/pull/55))
@@ -801,22 +711,15 @@
 - Print check results output when it contains errors ([#86](https://github.com/zopencommunity/meta/pull/86))
 - zopen-generate fixes (check for port in name + create .gitattributes file) ([#84](https://github.com/zopencommunity/meta/pull/84))
 - Added fix for issue https://github.com/ZOSOpenTools/utils/issues/81 ([#82](https://github.com/zopencommunity/meta/pull/82))
-- Add contributing.md file + fix tagging in zopen generate ([#78](https://github.com/zopencommunity/meta/pull/78))
 - Added fix for issue https://github.com/ZOSOpenTools/utils/issues/56 ([#69](https://github.com/zopencommunity/meta/pull/69))
 - fix chtag in git ([#72](https://github.com/zopencommunity/meta/pull/72))
 
-### 📚 Documentation
-- Add pre-req documentation + sidebar changes + progress page ([#58](https://github.com/zopencommunity/meta/pull/58))
-
-### 🔄 CI/CD
-- Adds support for specifying LIBS (needed to link with ZOSLIB) ([#76](https://github.com/zopencommunity/meta/pull/76))
-
 ### 🔍 Other Changes
+- Add pre-req documentation + sidebar changes + progress page ([#58](https://github.com/zopencommunity/meta/pull/58))
+- capture stderr from tests which could hold info on test statistics ([#83](https://github.com/zopencommunity/meta/pull/83))
+- Add contributing.md file + fix tagging in zopen generate ([#78](https://github.com/zopencommunity/meta/pull/78))
 - tolerate spaces in zopen_check_results output ([#75](https://github.com/zopencommunity/meta/pull/75))
 - More granular percentage + check for numbers in zopen_check_results o… ([#74](https://github.com/zopencommunity/meta/pull/74))
-
-### 🧪 Testing
-- capture stderr from tests which could hold info on test statistics ([#83](https://github.com/zopencommunity/meta/pull/83))
 
 ## September 2022
 ### ✨ Features
@@ -832,14 +735,6 @@
 - Fix return codes getting reset after piping to tee ([#60](https://github.com/zopencommunity/meta/pull/60))
 - Fix hardcoded paths by replacing them with ZOPEN_INSTALL_ROOT and then replace to the installed path in the .env ([#54](https://github.com/zopencommunity/meta/pull/54))
 
-### 📚 Documentation
-- Update Porting.md ([#42](https://github.com/zopencommunity/meta/pull/42))
-
-### 🔍 Other Changes
-- expand on FSUM problem ([#43](https://github.com/zopencommunity/meta/pull/43))
-- Display command output when verbose is active ([#58](https://github.com/zopencommunity/meta/pull/58))
-- preserve file permissions when modifying files in install dir ([#55](https://github.com/zopencommunity/meta/pull/55))
-
 ### 🧪 Testing
 - Always run tests and set TMPDIR ([#51](https://github.com/zopencommunity/meta/pull/51))
 - Test infrastructure changes + zopen generate updates + envar updates ([#63](https://github.com/zopencommunity/meta/pull/63))
@@ -847,36 +742,37 @@
 - Allow for optional running of tests and propogate test.status file ([#45](https://github.com/zopencommunity/meta/pull/45))
 - Allow ZOPEN_ROOT to be referenced in buildenv + Use variables for test return codes ([#62](https://github.com/zopencommunity/meta/pull/62))
 
-## August 2022
-### ✨ Features
-- add check that 'git' and 'xlclang' are 'new enough' ([#39](https://github.com/zopencommunity/meta/pull/39))
+### 🔍 Other Changes
+- expand on FSUM problem ([#43](https://github.com/zopencommunity/meta/pull/43))
+- Update Porting.md ([#42](https://github.com/zopencommunity/meta/pull/42))
+- Display command output when verbose is active ([#58](https://github.com/zopencommunity/meta/pull/58))
+- preserve file permissions when modifying files in install dir ([#55](https://github.com/zopencommunity/meta/pull/55))
 
+## August 2022
 ### 🐛 Bug Fixes
 - Build/Publish OCI images + misc fixes ([#38](https://github.com/zopencommunity/meta/pull/38))
 - Move accessory scripts to lib dir + fix for garbled characters in runAndLog ([#47](https://github.com/zopencommunity/meta/pull/47))
 - Fix description to source .env in current directory ([#20](https://github.com/zopencommunity/meta/pull/20))
-- Change PORT_INSTALL_DIR to ZOPEN_INSTALL_DIR + Update Latest.md + Fix attributes for png files ([#18](https://github.com/zopencommunity/meta/pull/18))
 - Fix build.groovy to run zopen build ([#14](https://github.com/zopencommunity/meta/pull/14))
 
 ### 📚 Documentation
 - docs: Update Porting.md ([#34](https://github.com/zopencommunity/meta/pull/34))
 - Update README.md to document zopen download ([#48](https://github.com/zopencommunity/meta/pull/48))
 - Update documentation ([#25](https://github.com/zopencommunity/meta/pull/25))
-
-### 🔄 CI/CD
-- add back in option to let us specify a sub-directory to build out of ([#46](https://github.com/zopencommunity/meta/pull/46))
+- Change PORT_INSTALL_DIR to ZOPEN_INSTALL_DIR + Update Latest.md + Fix attributes for png files ([#18](https://github.com/zopencommunity/meta/pull/18))
 
 ### 🔍 Other Changes
+- updates from Nate Myers suggestions ([#28](https://github.com/zopencommunity/meta/pull/28))
 - resolve commands before startShell ([#45](https://github.com/zopencommunity/meta/pull/45))
+- add back in option to let us specify a sub-directory to build out of ([#46](https://github.com/zopencommunity/meta/pull/46))
 - Primecache ([#43](https://github.com/zopencommunity/meta/pull/43))
 - Tag untracked files as well (new files created from patches) ([#41](https://github.com/zopencommunity/meta/pull/41))
-
-### 🔧 Maintenance
-- updates from Nate Myers suggestions ([#28](https://github.com/zopencommunity/meta/pull/28))
+- add check that 'git' and 'xlclang' are 'new enough' ([#39](https://github.com/zopencommunity/meta/pull/39))
 
 ## July 2022
 ### ✨ Features
 - Define env in common.inc + add C11 as default + continue downloading after bad extract ([#37](https://github.com/zopencommunity/meta/pull/37))
+- Add more details regarding CI/CD ([#16](https://github.com/zopencommunity/meta/pull/16))
 - add configure-minimal option so that ZLIB will be ok with configure ([#36](https://github.com/zopencommunity/meta/pull/36))
 - Add skipcheck option + show help when no params are passed to zopen ([#33](https://github.com/zopencommunity/meta/pull/33))
 
@@ -885,19 +781,13 @@
 - Update readme with zopen build changes ([#32](https://github.com/zopencommunity/meta/pull/32))
 - Added a tool (cloneall) and added doc on 'order to build' ([#12](https://github.com/zopencommunity/meta/pull/12))
 
-### 🔄 CI/CD
-- Add more details regarding CI/CD ([#16](https://github.com/zopencommunity/meta/pull/16))
-- zopen convention changes to script files + -e option to specify custom buildenv + -d option to specify deps search paths ([#27](https://github.com/zopencommunity/meta/pull/27))
-
 ### 🔍 Other Changes
 - Skip step if the command is not found ([#35](https://github.com/zopencommunity/meta/pull/35))
 - Checkexe ([#34](https://github.com/zopencommunity/meta/pull/34))
+- zopen convention changes to script files + -e option to specify custom buildenv + -d option to specify deps search paths ([#27](https://github.com/zopencommunity/meta/pull/27))
 - remove check that BOOTSTRAP and CONFIGURE are executable because need… ([#28](https://github.com/zopencommunity/meta/pull/28))
 
 ## June 2022
-### ✨ Features
-- Add info on creating a repo under zosopentools ([#10](https://github.com/zopencommunity/meta/pull/10))
-
 ### 🐛 Bug Fixes
 - Add support for PORT_EXTRA_CPPFLAGS PORT_EXTRA_CONFIGURE_OPTS + fix t… ([#17](https://github.com/zopencommunity/meta/pull/17))
 - Fix make check + log ([#16](https://github.com/zopencommunity/meta/pull/16))
@@ -908,29 +798,24 @@
 - Add initial pipeline documentation + add generate binaries page ([#8](https://github.com/zopencommunity/meta/pull/8))
 - improve doc ([da71f81](https://github.com/zopencommunity/meta/commit/da71f81b1be6acff9fc9ccd9397cfedfbfb4469a))
 
-### 🔄 CI/CD
-- Add initial cicd jenkins scripts to meta ([#11](https://github.com/zopencommunity/meta/pull/11))
-- Customize installation for Jenkins ([#11](https://github.com/zopencommunity/meta/pull/11))
-
 ### 🔍 Other Changes
+- Add info on creating a repo under zosopentools ([#10](https://github.com/zopencommunity/meta/pull/10))
+- Add initial cicd jenkins scripts to meta ([#11](https://github.com/zopencommunity/meta/pull/11))
 - Merge pull request #26 from ZOSOpenTools/jshimoda-dev ([ad3c5c2](https://github.com/zopencommunity/meta/commit/ad3c5c2be9be931391e9f57f4522312f5721a4fa))
 - Openssl enablement ([#21](https://github.com/zopencommunity/meta/pull/21))
 - WIP: download script for github releases ([#24](https://github.com/zopencommunity/meta/pull/24))
 - Some enhancements to build.sh ([#18](https://github.com/zopencommunity/meta/pull/18))
+- Customize installation for Jenkins ([#11](https://github.com/zopencommunity/meta/pull/11))
 - Help ([#12](https://github.com/zopencommunity/meta/pull/12))
 - moved build.sh details into build.sh ([5421784](https://github.com/zopencommunity/meta/commit/54217847641516356f61c59bd9e037559f263aca))
 - A few general enhancements to build.sh ([#7](https://github.com/zopencommunity/meta/pull/7))
-
-### 🔧 Maintenance
 - merge igors updates ([7bbe6da](https://github.com/zopencommunity/meta/commit/7bbe6da9d9a966533410933189d692374c34573e))
 
 ## May 2022
 ### ✨ Features
+- Adds colour coding of output, verbose output, and formats build.sh ([#8](https://github.com/zopencommunity/meta/pull/8))
 - added portcrtenv.sh for git ([#6](https://github.com/zopencommunity/meta/pull/6))
 - add in git attributes for easy z/os extraction ([f3e04e1](https://github.com/zopencommunity/meta/commit/f3e04e11c4e108355c9cad5aed60c709040163c1))
-
-### 💄 Style
-- Adds colour coding of output, verbose output, and formats build.sh ([#8](https://github.com/zopencommunity/meta/pull/8))
 
 ### 📚 Documentation
 - Update CommonSolutions.md ([5e12c4b](https://github.com/zopencommunity/meta/commit/5e12c4be2986b2365465638eca2a28f28e208c17))
@@ -946,9 +831,7 @@
 - Starter code for general purpose build.sh for ports ([#2](https://github.com/zopencommunity/meta/pull/2))
 
 ## November 2021
-### 📚 Documentation
-- Update README.md ([6aa1a69](https://github.com/zopencommunity/meta/commit/6aa1a6953a8f706c7f1a5bd18e484242cdb3e0a9))
-
 ### 🔍 Other Changes
+- Update README.md ([6aa1a69](https://github.com/zopencommunity/meta/commit/6aa1a6953a8f706c7f1a5bd18e484242cdb3e0a9))
 - Initial commit ([47ef9db](https://github.com/zopencommunity/meta/commit/47ef9db03436b70e8ea391f988ebc1b2513daf0c))
 

--- a/tools/create_changelog.py
+++ b/tools/create_changelog.py
@@ -1,0 +1,298 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "dulwich>=0.21.0",
+#     "typing-extensions>=4.0.0",
+# ]
+# ///
+
+import re
+from collections import defaultdict
+from datetime import datetime
+import argparse
+from dulwich.repo import Repo
+import sys
+from typing import Dict, List, Optional, Any
+
+# Configuration
+EXCLUDED_AUTHORS = {
+    b'zosopentools@ibm.com', b'ZOS Open Tools', b'zosopentools@gmail.com',
+    b'noreply@github.com', b'github-actions[bot]', b'actions@github.com'
+}
+
+# Repository configuration
+REPO_OWNER = "zopencommunity"
+REPO_URL = None  # Will be set after getting repo name
+
+EXCLUDED_PATTERNS = [
+    r'^Updating docs/apis/reference',
+    r'^Update CHANGELOG\.md',
+    r'^Update version',
+    r'^Automated commit',
+    r'^Generated changelog',
+    r'^Build:',
+    r'^Merge branch',
+    r'^Merge remote-tracking branch',
+    r'^Merge tag',
+    r'^Merge commit',
+    r'^Updating Latest\.md',
+    r'^Updating docs page',
+    r'^Updating docs/',
+    r'^Update Latest\.md'
+]
+
+CATEGORY_MAP = {
+    'feat': '✨ Features',
+    'fix': '🐛 Bug Fixes',
+    'docs': '📚 Documentation',
+    'doc': '📚 Documentation',  # Normalize 'doc' to same as 'docs'
+    'chore': '🔧 Maintenance',
+    'style': '💄 Style',
+    'refactor': '♻️ Refactoring',
+    'perf': '⚡️ Performance',
+    'test': '🧪 Testing',
+    'ci': '🔄 CI/CD'
+}
+
+def get_repo_name(repo: Repo) -> tuple[str, str]:
+    """Get organization and repository name from git config."""
+    try:
+        config = repo.get_config()
+        section = (b'remote', b'origin')
+
+        if config.has_section(section):
+            url = config.get(section, b'url')
+            if url:
+                url = url.decode('utf-8')
+                print(f"Debug: Git URL from config: {url}", file=sys.stderr)
+                # Handle both HTTPS and SSH URLs
+                if 'github.com' in url:
+                    # Only strip .git if it exists as a complete suffix
+                    if url.endswith('.git'):
+                        url = url[:-4]
+
+                    if url.startswith('git@'):
+                        # Handle SSH URL format (git@github.com:org/repo)
+                        path = url.split('github.com:')[1]
+                    else:
+                        # Handle HTTPS URL format (https://github.com/org/repo)
+                        path = url.split('github.com/')[1]
+
+                    print(f"Debug: Extracted path: {path}", file=sys.stderr)
+                    # Split into org and repo, handling potential subpaths
+                    parts = path.split('/')
+                    print(f"Debug: Split parts: {parts}", file=sys.stderr)
+                    if len(parts) >= 2:
+                        return parts[0], parts[1]
+
+        raise ValueError("Could not find valid GitHub remote URL")
+    except Exception as e:
+        print(f"Warning: Could not get repo info from git config: {e}", file=sys.stderr)
+        raise
+
+def get_commits() -> List[str]:
+    """Get filtered list of commits from the repository."""
+    try:
+        repo = Repo('.')
+    except Exception as e:
+        print(f"Error opening repository: {e}", file=sys.stderr)
+        return []
+
+    # Set repository URL based on repo name
+    global REPO_URL
+    try:
+        org, repo_name = get_repo_name(repo)
+        REPO_URL = f"https://github.com/{org}/{repo_name}"
+        print(f"Using repository: {REPO_URL}", file=sys.stderr)
+    except Exception as e:
+        print(f"Error getting repo info: {e}. Using default values.", file=sys.stderr)
+        REPO_URL = f"https://github.com/{REPO_OWNER}/zopen"
+
+    print("Processing commits...", file=sys.stderr)
+
+    # Get PR commits first
+    pr_commits = set()
+    for entry in repo.get_walker():
+        commit = entry.commit
+        if len(commit.parents) > 1:  # merge commit
+            for parent in commit.parents[1:]:
+                for c in repo.get_walker(include=[parent], exclude=[commit.parents[0]]):
+                    pr_commits.add(c.commit.id)
+
+    # Process all commits
+    commits = []
+    for entry in repo.get_walker():
+        commit = entry.commit
+        if commit.author in EXCLUDED_AUTHORS:
+            continue
+
+        message = commit.message.decode('utf-8')
+        if any(re.match(pattern, message.split('\n')[0].strip()) for pattern in EXCLUDED_PATTERNS):
+            continue
+        if commit.id in pr_commits and len(commit.parents) <= 1:
+            continue
+
+        date_str = datetime.fromtimestamp(commit.author_time).strftime('%Y-%m-%d %H:%M:%S')
+        is_merge = len(commit.parents) > 1
+        commits.append(f"{commit.id.decode('ascii')}|{message.split('\n')[0]}|{date_str}|{message}|{'merge' if is_merge else 'direct'}")
+
+    print(f"Processed {len(commits)} commits", file=sys.stderr)
+    return commits
+
+def categorize_pr(title: str) -> str:
+    """Categorize a PR or commit based on its title."""
+    title_lower = title.lower()
+
+    # First check for conventional commit format
+    conv_match = re.match(r'^(feat|fix|docs?|chore|style|refactor|perf|test|ci)(\(.*?\))?\s*:\s*', title_lower)
+    if conv_match:
+        tag = conv_match.group(1)
+        return CATEGORY_MAP.get(tag, '🔍 Other Changes')
+
+    # For non-conventional commits, try to infer the category
+    # Order matters: more common categories are checked first to maximize the chance of
+    # gathering enough related commits (>= 3) to avoid being scattered into "Other Changes"
+    if any(p in title_lower for p in ['doc', 'docs', 'documentation', 'guide', 'readme', 'md']):
+        return '📚 Documentation'
+    if any(p in title_lower for p in ['fix', 'bug', 'issue', 'error', 'typo']):
+        return '🐛 Bug Fixes'
+    if any(p in title_lower for p in ['feat', 'feature', 'add', 'support', 'implement']):
+        return '✨ Features'
+    if any(p in title_lower for p in ['ci', 'pipeline', 'jenkins', 'github actions', 'workflow']):
+        return '🔄 CI/CD'
+    if any(p in title_lower for p in ['test', 'testing', 'coverage']):
+        return '🧪 Testing'
+    if any(p in title_lower for p in ['refactor', 'cleanup', 'clean up', 'reorganize']):
+        return '♻️ Refactoring'
+    if any(p in title_lower for p in ['style', 'format', 'lint']):
+        return '💄 Style'
+    if any(p in title_lower for p in ['perf', 'performance', 'optimize', 'speed']):
+        return '⚡️ Performance'
+    if any(p in title_lower.split() for p in ['update', 'upgrade', 'maintenance', 'chore']):
+        return '🔧 Maintenance'
+
+    # Default case
+    return '🔍 Other Changes'
+
+def parse_commit(commit_info: str) -> Optional[Dict[str, Any]]:
+    """Parse a commit string into a structured format."""
+    try:
+        parts = commit_info.split('|')
+        if len(parts) < 5:
+            print(f"Warning: Malformed commit info: {commit_info}", file=sys.stderr)
+            return None
+
+        commit_hash, subject, date, full_message, commit_type = parts[:5]
+        title = None
+        pr_number = None
+
+        if commit_type == 'merge':
+            pr_match = re.search(r'Merge pull request #(\d+)[^\n]*\n+([^\n]+)', full_message)
+            if pr_match:
+                pr_number = pr_match.group(1)
+                title = pr_match.group(2).strip()
+            else:
+                pr_match = re.search(r'#(\d+)', subject)
+                if pr_match:
+                    pr_number = pr_match.group(1)
+                    title = full_message.split('\n')[1].strip() if len(full_message.split('\n')) > 1 else subject.strip()
+
+        title = title or subject.strip()
+        date_obj = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+
+        return {
+            'hash': commit_hash,
+            'title': title,
+            'pr_number': pr_number,
+            'date': date_obj,
+            'month_year': date_obj.strftime('%B %Y'),
+            'type': commit_type
+        }
+    except Exception as e:
+        print(f"Error parsing commit: {e}", file=sys.stderr)
+        return None
+
+def format_commit_entry(commit: Dict[str, Any]) -> str:
+    """Format a commit entry for the changelog."""
+    if commit['pr_number'] and REPO_URL:
+        return f"{commit['title']} ([#{commit['pr_number']}]({REPO_URL.rstrip('/')}/pull/{commit['pr_number']}))"
+    elif REPO_URL:
+        return f"{commit['title']} ([{commit['hash'][:7]}]({REPO_URL.rstrip('/')}/commit/{commit['hash']}))"
+    return commit['title']
+
+def generate_changelog(prs_by_month: Dict) -> str:
+    """Generate the changelog content."""
+    content = ["# Changelog\n"]
+    current_month = datetime.now().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    for month_date, prs_by_category in sorted(prs_by_month.items(), reverse=True):
+        month_header = month_date.strftime('%B %Y')
+        if month_date == current_month:
+            month_header += " 🚧"
+
+        content.append(f"## {month_header}\n")
+
+        # First, collect all commits by category
+        merged_categories = defaultdict(list)
+        other_changes = []
+
+        # Process all commits, keeping "Other Changes" separate
+        for category, commits in prs_by_category.items():
+            if category == '🔍 Other Changes':
+                other_changes.extend(commits)
+            else:
+                merged_categories[category].extend(commits)
+
+        # Move small categories (< 3 commits) to other_changes
+        for category, commits in list(merged_categories.items()):
+            if len(commits) < 3:
+                other_changes.extend(commits)
+                del merged_categories[category]
+
+        # Output regular categories first (sorted alphabetically)
+        for category in sorted(merged_categories.keys()):
+            commits = merged_categories[category]
+            content.append(f"### {category}\n")
+            for pr in sorted(commits, key=lambda x: (x['date'], int(x['pr_number'] or 0)), reverse=True):
+                content.append(f"- {format_commit_entry(pr)}\n")
+            content.append("\n")
+
+        # Output Other Changes section last if there are any
+        if other_changes:
+            content.append("### 🔍 Other Changes\n")
+            for pr in sorted(other_changes, key=lambda x: (x['date'], int(x['pr_number'] or 0)), reverse=True):
+                content.append(f"- {format_commit_entry(pr)}\n")
+            content.append("\n")
+
+    return "".join(content)
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description='Generate CHANGELOG.md from git merge commits and direct pushes')
+    parser.add_argument('--output', '-o', default='CHANGELOG.md', help='Output changelog file path')
+    args = parser.parse_args()
+
+    commits = get_commits()
+    if not commits:
+        print("No commits found or error occurred", file=sys.stderr)
+        sys.exit(1)
+
+    prs_by_month = defaultdict(lambda: defaultdict(list))
+
+    for commit_info in commits:
+        commit = parse_commit(commit_info)
+        if commit:
+            month = commit['date'].replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            category = categorize_pr(commit['title'])
+            prs_by_month[month][category].append(commit)
+
+    try:
+        with open(args.output, 'w') as f:
+            f.write(generate_changelog(prs_by_month))
+        print(f"Successfully generated changelog at {args.output}", file=sys.stderr)
+    except IOError as e:
+        print(f"Error writing changelog: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/tools/create_release_notes.sh
+++ b/tools/create_release_notes.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+
+set -e  # Exit on error
+
+# Parse command line arguments
+MODE="retro"  # Default mode
+PROJECTS=""
+LIMIT=250
+
+print_usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Options:"
+    echo "  -m, --mode MODE     Operation mode: 'retro' (update all releases) or 'release' (generate for new release)"
+    echo "  -p, --projects LIST Comma-separated list of projects (default: all zopencommunity projects)"
+    echo "  -l, --limit NUM     Limit number of releases to process (default: 250)"
+    echo "  -h, --help          Show this help message"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -m|--mode)
+            MODE="$2"
+            if [[ "$MODE" != "retro" && "$MODE" != "release" ]]; then
+                echo "Error: Mode must be either 'retro' or 'release'"
+                exit 1
+            fi
+            shift 2
+            ;;
+        -p|--projects)
+            PROJECTS="$2"
+            shift 2
+            ;;
+        -l|--limit)
+            LIMIT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+# Get projects list if not specified
+if [ -z "$PROJECTS" ]; then
+    PROJECTS=$(gh repo list zopencommunity -L 300 --json name --jq .[].name)
+else
+    # Convert comma-separated list to space-separated
+    PROJECTS=$(echo "$PROJECTS" | tr ',' ' ')
+fi
+
+# Create a temporary directory for release notes
+TEMP_DIR=$(mktemp -d)
+echo "Using temporary directory: $TEMP_DIR"
+
+# Global rate limit tracking
+RATE_REMAINING=5000  # Default GitHub rate limit
+RATE_RESET=0
+
+# Function to check and wait for rate limits
+check_rate_limit() {
+    local current_time
+    current_time=$(date +%s)
+
+    # Only check rate limit when we're running low or past reset time
+    if [ "$RATE_REMAINING" -le 100 ] || [ "$current_time" -ge "$RATE_RESET" ]; then
+        local rate_info
+        rate_info=$(gh api /rate_limit)
+        RATE_REMAINING=$(echo "$rate_info" | jq -r '.resources.core.remaining')
+        RATE_RESET=$(echo "$rate_info" | jq -r '.resources.core.reset')
+    fi
+
+    if [ "$RATE_REMAINING" -le 1 ]; then
+        local wait_time=$((RATE_RESET - current_time + 1))
+        echo "Rate limit nearly exhausted (${RATE_REMAINING} remaining). Waiting ${wait_time} seconds for reset..."
+        sleep "$wait_time"
+        # Refresh our rate limit info after waiting
+        rate_info=$(gh api /rate_limit)
+        RATE_REMAINING=$(echo "$rate_info" | jq -r '.resources.core.remaining')
+        RATE_RESET=$(echo "$rate_info" | jq -r '.resources.core.reset')
+    fi
+
+    # Decrement our remaining count
+    RATE_REMAINING=$((RATE_REMAINING - 1))
+}
+
+# Function to handle GitHub API calls with error checking
+gh_api_call() {
+    local endpoint="$1"
+    local output_file="$2"
+    local max_retries=3
+    local retry_count=0
+
+    while true; do
+        check_rate_limit
+
+        if output=$(gh api "$endpoint" 2>&1); then
+            echo "$output" > "$output_file"
+            return 0
+        else
+            echo "API call to $endpoint failed with error: $output" >&2
+        fi
+
+        retry_count=$((retry_count + 1))
+        if [ $retry_count -ge $max_retries ]; then
+            echo "Failed to call GitHub API after $max_retries attempts" >&2
+            echo "Last error: $output" >&2
+            return 1
+        fi
+
+        echo "API call failed, retrying in 5 seconds..." >&2
+        sleep 5
+    done
+}
+
+# Function to format commit message
+format_commit_message() {
+    local commit_sha="$1"
+    local commit_msg="$2"
+    local project="$3"
+
+    # Get the first line and clean up whitespace, preserving important content
+    local first_line
+    first_line=$(echo "$commit_msg" | head -n1)
+
+    # Skip merge commits and empty messages
+    if [[ "$first_line" =~ ^Merge\ (pull\ request|branch) ]] || [ -z "$first_line" ]; then
+        return
+    fi
+
+    # Extract just the 40-character SHA
+    commit_sha=$(echo "$commit_sha" | grep -o '[0-9a-f]\{40\}')
+
+    # Create the commit link
+    local commit_link="[${commit_sha:0:7}](https://github.com/zopencommunity/${project}/commit/${commit_sha})"
+
+    # Clean up the message while preserving content in parentheses
+    first_line=$(echo "$first_line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+    # If it's a conventional commit format (type(scope): message)
+    if [[ "$first_line" =~ ^([^(:]+)(\([^)]+\)):(.+)$ ]]; then
+        local type="${BASH_REMATCH[1]}"
+        local scope="${BASH_REMATCH[2]}"
+        local message="${BASH_REMATCH[3]}"
+
+        # Clean up the message while preserving content
+        message=$(echo "$message" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+        printf "* %s%s:%s (%s)\n" "$type" "$scope" "$message" "$commit_link"
+    else
+        # For regular commit messages, preserve the full message
+        if [ -n "$first_line" ]; then
+            printf "* %s (%s)\n" "$first_line" "$commit_link"
+        fi
+    fi
+}
+
+# Function to create release notes for a comparison
+create_release_notes() {
+    local repo="$1"
+    local prev_tag="$2"
+    local curr_tag="$3"
+    local output_file="$4"
+
+    local title="## [Changes ${prev_tag}...${curr_tag}](https://github.com/${repo}/compare/${prev_tag}...${curr_tag})"
+    generate_notes "$repo" "$prev_tag" "$curr_tag" "$output_file" "$title"
+}
+
+# Function to create release notes for unreleased changes
+create_unreleased_notes() {
+    local repo="$1"
+    local last_tag="$2"
+    local output_file="$3"
+
+    local title="## [Changes since ${last_tag}](https://github.com/${repo}/compare/${last_tag}...HEAD)"
+    generate_notes "$repo" "$last_tag" "HEAD" "$output_file" "$title"
+}
+
+# Shared function to generate release notes
+generate_notes() {
+    local repo="$1"
+    local base_ref="$2"
+    local target_ref="$3"
+    local output_file="$4"
+    local title="$5"
+
+    # Extract project name from repo
+    local project
+    project=$(echo "$repo" | cut -d'/' -f2)
+
+    # Get the comparison data
+    local compare_file="${TEMP_DIR}/compare.json"
+    if ! gh_api_call "repos/${repo}/compare/${base_ref}...${target_ref}" "$compare_file"; then
+        echo "Error getting comparison data, skipping..."
+        rm -f "$compare_file"
+        return 1
+    fi
+
+    # Create the release notes
+    {
+        echo "$title"
+        echo ""
+        echo "### Pull Requests"
+    } > "$output_file"
+
+    # Process PRs
+    local has_prs=false
+    declare -A pr_commit_map
+
+    while read -r line; do
+        message=$(echo "$line" | jq -r '.message')
+        sha=$(echo "$line" | jq -r '.sha')
+
+        if [ -z "$message" ]; then
+            continue
+        fi
+        pr_num=$(echo "$message" | sed -n 's/^Merge pull request #\([0-9]\+\).*/\1/p')
+        if [ -n "$pr_num" ]; then
+            local pr_file="${TEMP_DIR}/pr.json"
+            if gh_api_call "repos/${repo}/pulls/${pr_num}" "$pr_file"; then
+                pr_title=$(jq -r '.title' "$pr_file")
+                pr_title=${pr_title//[[\]]/}
+                echo "* ${pr_title} ([#${pr_num}](https://github.com/${repo}/pull/${pr_num}))" >> "$output_file"
+                has_prs=true
+
+                local commits_file="${TEMP_DIR}/commits.json"
+                if gh_api_call "repos/${repo}/pulls/${pr_num}/commits" "$commits_file"; then
+                    while read -r commit_sha; do
+                        if [ -n "$commit_sha" ]; then
+                            pr_commit_map["$commit_sha"]=1
+                        fi
+                    done < <(jq -r '.[].sha' "$commits_file")
+                fi
+                rm -f "$commits_file"
+            fi
+            rm -f "$pr_file"
+        fi
+    done < <(jq -r '.commits[] | {message: .commit.message, sha: .sha} | tojson' "$compare_file")
+
+    if [ "$has_prs" = false ]; then
+        echo "No pull requests found in this period." >> "$output_file"
+    fi
+
+    # Process direct commits
+    echo -e "\n### Direct Changes" >> "$output_file"
+    local has_direct=false
+
+    while read -r line; do
+        message=$(echo "$line" | jq -r '.message')
+        sha=$(echo "$line" | jq -r '.sha')
+
+        if [ -z "$message" ] || echo "$message" | grep -q '^Merge pull request'; then
+            continue
+        fi
+
+        first_line=$(echo "$message" | head -n1)
+        if [[ "$first_line" =~ ^Updating\ docs/apis ]] || \
+           [[ "$first_line" =~ ^Reorder\ doc\ updates ]] || \
+           [[ "$first_line" =~ ^Update\ .*\.md$ ]]; then
+            continue
+        fi
+
+        if [ -n "$sha" ] && [ -z "${pr_commit_map[$sha]+x}" ]; then
+            format_commit_message "$sha" "$message" "$project" >> "$output_file"
+            has_direct=true
+        fi
+    done < <(jq -r '.commits[] | {message: .commit.message, sha: .sha} | tojson' "$compare_file")
+
+    if [ "$has_direct" = false ]; then
+        echo "No direct changes in this period." >> "$output_file"
+    fi
+
+    rm -f "$compare_file"
+    return 0
+}
+
+# Process each project
+for project in $PROJECTS; do
+    echo "Processing project: $project"
+    REPO="zopencommunity/$project"
+
+    # Get releases
+    RELEASES=$(gh release list --limit "$LIMIT" --repo "$REPO" --json name,tagName,publishedAt --order asc)
+    if [ -z "$RELEASES" ]; then
+        echo "No releases found for $REPO, skipping..."
+        continue
+    fi
+
+    if [ "$MODE" = "retro" ]; then
+        # Process all releases retrospectively
+        prev_tag=""
+        echo "$RELEASES" | jq -r '.[] | .tagName' | while read -r curr_tag; do
+            if [ -n "$prev_tag" ]; then
+                notes_file="${TEMP_DIR}/${project}_${curr_tag}_notes.md"
+                if create_release_notes "$REPO" "$prev_tag" "$curr_tag" "$notes_file"; then
+                    echo "Would execute: gh release edit --repo $REPO $curr_tag --notes-file $notes_file"
+                    # Uncomment the following line to actually update the release notes
+                    # gh release edit --repo "$REPO" "$curr_tag" --notes-file "$notes_file"
+                fi
+            fi
+            prev_tag="$curr_tag"
+        done
+    else
+        # Get the latest release tag and date - releases are in ascending order, .[-1] gives us the newest item
+        LATEST_TAG=$(echo "$RELEASES" | jq -r '.[-1].tagName')
+        if [ -n "$LATEST_TAG" ]; then
+            if [ "$project" = "metaport" ]; then
+                # Special handling for metaport - get both metaport and meta changes
+                echo "Processing metaport changes..."
+                notes_file="${TEMP_DIR}/${project}_unreleased_notes.md"
+                if create_unreleased_notes "$REPO" "$LATEST_TAG" "$notes_file"; then
+                    echo "Generated release notes for unreleased metaport changes in $notes_file"
+                    cat "$notes_file"
+                fi
+
+                # Get the latest release date for metaport
+                LATEST_DATE=$(echo "$RELEASES" | jq -r '.[-1].publishedAt' | cut -d'T' -f1)
+                if [ -n "$LATEST_DATE" ]; then
+                    echo "Processing meta changes since ${LATEST_DATE}..."
+
+                    # Find the meta commit hash from the release date
+                    meta_commit_file="${TEMP_DIR}/meta_commit.json"
+                    if gh_api_call "repos/zopencommunity/meta/commits?until=${LATEST_DATE}T23:59:59Z&per_page=1" "$meta_commit_file"; then
+                        META_COMMIT=$(jq -r '.[0].sha' "$meta_commit_file")
+                        if [ -n "$META_COMMIT" ] && [ "$META_COMMIT" != "null" ]; then
+                            meta_notes_file="${TEMP_DIR}/meta_unreleased_notes.md"
+                            # Create notes for meta changes since the commit at release date
+                            if create_unreleased_notes "zopencommunity/meta" "$META_COMMIT" "$meta_notes_file"; then
+                                echo "Generated release notes for unreleased meta changes in $meta_notes_file"
+                                cat "$meta_notes_file"
+                            fi
+                        else
+                            echo "Could not find meta commit for date ${LATEST_DATE}"
+                        fi
+                        rm -f "$meta_commit_file"
+                    fi
+                fi
+            else
+                notes_file="${TEMP_DIR}/${project}_unreleased_notes.md"
+                if create_unreleased_notes "$REPO" "$LATEST_TAG" "$notes_file"; then
+                    echo "Generated release notes for unreleased changes in $notes_file"
+                    cat "$notes_file"
+                fi
+            fi
+        fi
+    fi
+done
+
+echo "Temporary directory $TEMP_DIR contains all generated files"
+# Cleanup commented out for inspection
+# rm -rf "$TEMP_DIR"


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Content Update

## Category

- [ ] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [x] CI/CD
- [x] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->

`create_changelog.py` uses a new, from-scratch python git mgmt package called [dulwich](https://www.dulwich.io/), to work with (locally available) git repo data. At the top, it has PEP 723 inline script metadata. This allows the venv management to become invisible when using `uv` as the package manager; so you can do `uv run create_changelog.py`, and it'll deal with packages and venv behind the scenes. This script shows both PRs and direct commits to a repo, filtering out some hard-coded automated commits. Categories with <3 commits are lumped together into 'Other'.

`create_release_notes.py` uses gh cli. All commits/PRs/titles are clickable links to the relevant GitHub pages. Since `meta` is released via `metaport`, when this is run against `metaport`, it creates notes for `metaport` itself (ex: buildenv changes), and for `meta`. It has rate-limiting support because when this is run against the whole org to retroactively update (>500 ?) release notes across 250+ projects, we're bound to hit it.

gh cli commands used:
- `gh repo list`
- `gh api`
  - `/rate_limit`
  - `/repos/{repo}/compare`
  - `/repos/{repo}/pulls`
  - `/repos/{repo}/pulls/{number}/commits`
  - `/repos/{repo}/commits`
- `gh release list`
- `gh release edit`

## Outputs from sample invocations

```sh
 ~  _dev  zopen-release-notes  meta   chglog-relnotes  3✔  uv run tools/create_changelog.py --output CHANGELOG.md
Installed 3 packages in 5ms
Debug: Git URL from config: https://github.com/zopencommunity/meta/
Debug: Extracted path: zopencommunity/meta/
Debug: Split parts: ['zopencommunity', 'meta', '']
Using repository: https://github.com/zopencommunity/meta
Processing commits...
Processed 599 commits
Successfully generated changelog at CHANGELOG.md


 ~  _dev  zopen-release-notes  meta   chglog-relnotes  3✔  2✎  tools/create_release_notes.sh -m retro -p "mesonport"
Using temporary directory: /tmp/tmp.qElrKXjZ3p
Processing project: mesonport
Would execute: gh release edit --repo zopencommunity/mesonport STABLE_mesonport_2787 --notes-file /tmp/tmp.qElrKXjZ3p/mesonport_STABLE_mesonport_2787_notes.md
Would execute: gh release edit --repo zopencommunity/mesonport STABLE_mesonport_3029 --notes-file /tmp/tmp.qElrKXjZ3p/mesonport_STABLE_mesonport_3029_notes.md
Temporary directory /tmp/tmp.qElrKXjZ3p contains all generated files


 ~  _dev  zopen-release-notes  meta   chglog-relnotes  3✔  2✎  tools/create_release_notes.sh -m retro -p "meta"
Using temporary directory: /tmp/tmp.Zsbfgugj7E
Processing project: meta
Would execute: gh release edit --repo zopencommunity/meta v0.8.0 --notes-file /tmp/tmp.Zsbfgugj7E/meta_v0.8.0_notes.md
Temporary directory /tmp/tmp.Zsbfgugj7E contains all generated files


 ~  _dev  zopen-release-notes  meta   chglog-relnotes  3✔  2✎  tools/create_release_notes.sh -m retro -p "metaport"
Using temporary directory: /tmp/tmp.3Y0xI9QGuw
Processing project: metaport
Would execute: gh release edit --repo zopencommunity/metaport metaport_389 --notes-file /tmp/tmp.3Y0xI9QGuw/metaport_metaport_389_notes.md
Would execute: gh release edit --repo zopencommunity/metaport metaport_390 --notes-file /tmp/tmp.3Y0xI9QGuw/metaport_metaport_390_notes.md
Temporary directory /tmp/tmp.3Y0xI9QGuw contains all generated files


 ~  _dev  zopen-release-notes  meta   chglog-relnotes  3✔  2✎  tools/create_release_notes.sh -m release -p "metaport"
Using temporary directory: /tmp/tmp.d5glQ12ZKk
Processing project: metaport
Processing metaport changes...
Generated release notes for unreleased metaport changes in /tmp/tmp.d5glQ12ZKk/metaport_unreleased_notes.md
## [Changes since metaport_390](https://github.com/zopencommunity/metaport/compare/metaport_390...HEAD)

### Pull Requests
* Add cacert support and clean up 'meta' prod directory so it isn't meta/meta ([#1](https://github.com/zopencommunity/metaport/pull/1))
...

### Direct Changes
* clean up append_to_setup code to handle re-run ([95eb22f](https://github.com/zopencommunity/metaport/commit/95eb22fad405b3095eaa105a974b33814322415d))
...

Processing meta changes since 2023-01-17...
Generated release notes for unreleased meta changes in /tmp/tmp.d5glQ12ZKk/meta_unreleased_notes.md
## [Changes since 5bf4e009f22b3006fa010f169654ac9cf285046f](https://github.com/zopencommunity/meta/compare/5bf4e009f22b3006fa010f169654ac9cf285046f...HEAD)

### Pull Requests
* Add a prompt, plus improve messaging to inform the user about the zopen overriding behaviour on conflicting tools ([#926](https://github.com/zopencommunity/meta/pull/926))
...

### Direct Changes
* Update usage.zopen.community urls ([728d8ef](https://github.com/zopencommunity/meta/commit/728d8efa4d9716ded35dc4674ebc8a437d89ee3d))
...
Temporary directory /tmp/tmp.d5glQ12ZKk contains all generated files
```

![Screenshot From 2025-02-16 11-05-47](https://github.com/user-attachments/assets/73676305-8384-4136-9d5b-9ff4d1e76e6e)
![Screenshot From 2025-02-16 11-11-11](https://github.com/user-attachments/assets/9f83e362-aad8-4671-8fc2-593299d9464a)
![Screenshot From 2025-02-16 11-15-48](https://github.com/user-attachments/assets/78517aad-2d36-4966-a240-c5ea056ffcd0)



## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?

Yes, can test `create_release_notes.sh` in retro mode, and then have to run it against the whole zopencommunity org.
This is to update past release notes with info from commits.

Then, can invoke the same script in release mode when making a release.

**Note:**
2 commands have limits in them. They are to limit the # of repos returned in an org, and to limit the releases in a repo that will be processed.
`gh repo list zopencommunity -L 300 --json name --jq .[].name`
`gh release list --limit "$LIMIT" --repo "$REPO" --json name,tagName,publishedAt --order asc`

`create_changelog.py` use is optional. I started here as a way of getting used to dulwich.
It can serve as an example of interacting with a `.git` dir, if needed, and if CHANGELOG.md is needed in addition to release notes in the /releases page.
