### PR TITLE
zopen_install.sh: Clean up pax file after extraction

### DIFF
--- a/tools/zopen_install.sh
+++ b/tools/zopen_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# 
+#
 # Quick Install tool for zopen's meta package
 # Assumes you have Curl and Bash installed (likely through Open Enterprise Foundation)
 # Downloads and extracts meta into the current directory
@@ -49,13 +49,22 @@ if [ $? -gt 0 ]; then
   exit 1
 fi
 
+echo "> Cleaning up pax file $paxFile..."
+rm -vf "$paxFile"
+if [ $? -gt 0 ]; then
+   echo "Warning: Failed to remove pax file $paxFile. Installation will continue, but space might not be freed."
+fi
+
+
 dir=$(echo "$paxOutput" | head -1)
 if [ ! -d "$dir" ]; then
   echo "Error: $dir is not a valid directory."
   exit 1
 fi
 
-set -e
+# From this point on, exit immediately if a command exits with a non-zero status.
+set -e 
+
 echo "> Moving to extracted directory..."
 cd "$dir"
 
@@ -65,6 +74,9 @@ source ./.env
 echo "> Initializing zopen tools..."
 zopen init
 
-echo "> Cleaning up..."
-rm -rvf $paxFile
+echo "> Cleaning up extracted directory..."
 rm -rvf $dir
+
+echo "> zopen meta package installed successfully and cleanup complete."
+
+exit 0 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
Modifies the zopen_install.sh script to delete the meta-main.*pax.Z file ( $paxFile ) immediately after it has been successfully extracted.

## Related Issues

- Related Issue #
- Closes # https://github.com/zopencommunity/meta/issues/959

## [optional] Are there any post-deployment tasks or follow-up actions required?
