### PR TITLE
Use shallow clones by default for build speedup

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -140,15 +140,18 @@ Restricted Usage (meta):
   ZOPEN_SHELL                     Specify an alternate shell to use if -s
                                   option specified. (defaults to /bin/sh)
 
-Being reworked to move to common ZOPEN_xxx_GIT_REFS:
-  ZOPEN_DEV_BRANCH      The branch that the git repo should checkout.
-                        (default is repo default)
-  ZOPEN_DEV_TAG         The tag that the git repo should checkout as a branch.
-                        (optional)
-  ZOPEN_STABLE_BRANCH   The branch that the stable repo should checkout.
-                        (default is repo default)
-  ZOPEN_STABLE_TAG      The tag that the git repo should checkout as a branch.
-                        (optional)
+Git variables:
+  ZOPEN_DEV_BRANCH        The branch that the git repo should checkout.
+                          (default is repo default)
+  ZOPEN_DEV_TAG           The tag that the git repo should checkout as a branch.
+                          (optional)
+  ZOPEN_STABLE_BRANCH     The branch that the stable repo should checkout.
+                          (default is repo default)
+  ZOPEN_STABLE_TAG        The tag that the git repo should checkout as a branch.
+                          (optional)
+  ZOPEN_CLONE_SUBMODULES  Set to "yes" to recursively clone submodules.
+  ZOPEN_CLONE_FULL        Set to "yes" to perform a full clone as opposed to the
+                          default shallow clone (depth of 1).
 
 Currently unused:
   ZOPEN_DEV_TYPE        The type of package to download. Valid types are
@@ -937,10 +940,18 @@ gitClone()
   else
     freshBuild=true
     printInfo "Clone and create ${dir}"
-    if [ "${ZOPEN_CLONE_SUBMODULES}" = "yes" ]; then
-      gitOptions=" --recurse-submodules"
+
+    shallowCloneOption="--depth 1"
+    if [ "${ZOPEN_CLONE_FULL}" = "yes" ]; then
+      shallowCloneOption=""
     fi
-    if ! runAndLog "git clone \"${ZOPEN_URL}\" ${gitOptions}"; then
+
+    gitOptions=""
+    if [ "${ZOPEN_CLONE_SUBMODULES}" = "yes" ]; then
+      gitOptions="--recurse-submodules"
+    fi
+
+    if ! runAndLog "git clone ${shallowCloneOption} \"${ZOPEN_URL}\" ${gitOptions}"; then
       printError "Unable to clone ${gitname} from ${ZOPEN_URL}"
     fi
     if [ -n "${ZOPEN_GIT_BRANCH}" ]; then


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
This should improve clone time by at least 10x. Most of the time we only need to a shallow clone, and the history is only important when debugging. The user can set ZOPEN_CLONE_FULL="yes" if they want to do a full clone. We could add an option if desired.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
