### PR TITLE
Added functionality to download descriptions.json and print out package descriptions when zopen-info is run

### DIFF
--- a/bin/zopen-info
+++ b/bin/zopen-info
@@ -93,10 +93,14 @@ printPackageInfo() {
     community_commitsha=$(echo "${remote_data}" | jq -r '.assets[0].community_commitsha')
     runtime_dependencies=$(echo "${remote_data}" | jq -r '.assets[0].runtime_dependencies') 
     build_dependencies=$(jq -r '.product.build_dependencies | unique_by(.name) | map(.name) | join(" ")' ${metadataFile})
-
+    package_descriptions=$(jq -r --arg base_package "$base_package" '.descriptions[$base_package]' "${JSON_DESCRIPTIONS_CACHE}")
+   
     printHeader "==> ${name} (Not Installed)"
 
     printHeader "==> Package"
+    if [ -n "$package_descriptions" ]; then
+    	printf "%-20s %s\n" "Description:" "$package_descriptions"
+    fi
     printf "%-20s %s\n" "Version:" "${version}"
     printf "%-20s %s\n" "Release:" "${release}"
     printf "%-20s %s\n" "Buildline:" "${buildline}"
@@ -163,6 +167,7 @@ printPackageInfo() {
     size=$(jq -r '.product.size' "${metadata}")
     commitsha=$(jq -r '.product.commitsha' "${metadata}")
     community_commitsha=$(jq -r '.product.community_commitsha' "${metadata}")
+    package_descriptions=$(jq -r --arg package "$package"  '.descriptions[$package]' "${JSON_DESCRIPTIONS_CACHE}")
 
     # Use jq's --exit-status option to handle null values gracefully
     build_dependencies=$(jq -r '.product.build_dependencies | map(.name) | join(", ")' --exit-status "${metadata}")
@@ -191,7 +196,11 @@ printPackageInfo() {
     installed_path=$(cd "${ZOPEN_PKGINSTALL}/${package}/${package}" > /dev/null 2>&1 && pwd -P)
 
     printHeader "==> ${name}: ${buildline} ${dotversion}"
-    printf "%-20s %s\n" "Description:" "${summary}"
+    if [ -n "$package_descriptions" ]; then
+  	printf "%-20s %s\n" "Description:" "$package_descriptions"
+    else
+  	printf "%-20s %s\n" "Description:" "$summary"
+    fi
 
     printHeader "==> Package"
     printf "%-20s %s\n" "Version:" "${dotversion}"
@@ -203,7 +212,6 @@ printPackageInfo() {
     printf "%-20s %s\n" "GitHub:" "${repo}"
     printf "%-20s %s\n" "License:" "${license}"
     printf "%-20s %s\n" "zopen license:" "${zopen_license}"
-
     printHeader "==> Installation Details"
     printf "%-20s %s\n" "Installed:" "Yes"
     printf "%-20s %s\n" "Installation Path:" "${installed_path}"

--- a/include/common.sh
+++ b/include/common.sh
@@ -1241,7 +1241,7 @@ downloadJSONCache()
     cachedir="${ZOPEN_ROOTFS}/var/cache/zopen"
     [ ! -e "${cachedir}" ] && mkdir -p "${cachedir}"
     JSON_CACHE="${cachedir}/zopen_releases.json"
-    JSON_DESCRIPTIONS_CACHE=${cachedir}/zopen_releases_descriptions.json"
+    JSON_DESCRIPTIONS_CACHE="${cachedir}/zopen_releases_descriptions.json"
     JSON_TIMESTAMP="${cachedir}/zopen_releases.timestamp"
     JSON_TIMESTAMP_CURRENT="${cachedir}/zopen_releases.timestamp.current"
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -14,6 +14,7 @@ zopenInitialize()
   fi
   ZOPEN_ANALYTICS_JSON="${ZOPEN_ROOTFS}/var/lib/zopen/analytics.json"
   ZOPEN_JSON_CACHE_URL="https://raw.githubusercontent.com/zopencommunity/meta/main/docs/api/zopen_releases.json"
+  ZOPEN_DESCRIPTIONS_CACHE_URL="https://raw.githubusercontent.com/ZOSOpenTools/meta/main/docs/api/zopen_releases_descriptions.json"
   ZOPEN_JSON_CONFIG="${ZOPEN_ROOTFS}/etc/zopen/config.json"
   if [ -n "${INCDIR}" ]; then
     ZOPEN_SYSTEM_PREREQ_SCRIPT="${INCDIR}/prereq.sh"
@@ -1240,6 +1241,7 @@ downloadJSONCache()
     cachedir="${ZOPEN_ROOTFS}/var/cache/zopen"
     [ ! -e "${cachedir}" ] && mkdir -p "${cachedir}"
     JSON_CACHE="${cachedir}/zopen_releases.json"
+    JSON_DESCRIPTIONS_CACHE=${cachedir}/zopen_releases_descriptions.json"
     JSON_TIMESTAMP="${cachedir}/zopen_releases.timestamp"
     JSON_TIMESTAMP_CURRENT="${cachedir}/zopen_releases.timestamp.current"
 
@@ -1276,6 +1278,12 @@ downloadJSONCache()
       printError "Failed to obtain json cache from ${ZOPEN_JSON_CACHE_URL}; ${curlout}"
     fi
     chtag -tc 819 "${JSON_CACHE}"
+
+    if ! curlout=$(curlCmd -L --no-progress-meter -o "${JSON_DESCRIPTIONS_CACHE}" "${ZOPEN_DESCRIPTIONS_CACHE_URL}"); then
+      printError "Failed to obtain descriptions  cache from ${ZOPEN_DESCRIPTIONS_CACHE_URL}; ${curlout}"
+    fi
+    chtag -tc 819 "${JSON_DESCRIPTIONS_CACHE}"
+
   fi
 
   if [ ! -f "${JSON_CACHE}" ]; then


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
