### PR TITLE
Add --print-source-dir in zopen-build to display the source directory

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -381,6 +381,8 @@ processOptions()
   forceUpgradeDeps=false
   noInstallRuntimeDeps=false
   instrument=false
+  printSourceDir=false
+  noInfoMessages=false
   depsDepth=2
   while [ $# -gt 0 ]; do
     case $1 in
@@ -404,6 +406,10 @@ processOptions()
       ;;
     "-u" | "--upgradeDeps")
       forceUpgradeDeps=true
+      ;;
+    "--print-source-dir")
+      printSourceDir=true
+      noInfoMessages=true
       ;;
     "--forcepatchapply")
       forcePatchApply=true
@@ -479,7 +485,6 @@ processOptions()
 signPaxFile()
 {
   # Paths to your files
-  printHeader "Signing pax file ${paxFileName}"
   printHeader "Signing pax file ${paxFileName}"
   PRIVATE_KEY="${ZOPEN_GPG_SECRET_KEY_FILE}"
   PASSPHRASE_FILE="${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}"
@@ -937,6 +942,10 @@ gitClone()
 {
   gitname=$(basename "${ZOPEN_URL}")
   dir=${gitname%%.*}
+  if $printSourceDir; then
+    echo $dir  
+    exit 0
+  fi
   if [ -d "${dir}" ]; then
     printInfo "Using existing git clone'd directory ${dir}"
   else
@@ -965,7 +974,6 @@ gitClone()
     fi
     tagTree "${dir}"
   fi
-  echo "${dir}"
 }
 
 extractTarBall()
@@ -1068,6 +1076,10 @@ downloadTarBall()
   dir=${tarballz%%.tar.*}
   dir=${dir%%.tgz}
   dir=${dir%%.zip}
+  if $printSourceDir; then
+    echo $dir  
+    exit 0
+  fi
   if [ -d "${dir}" ]; then
     echo "Using existing tarball directory ${dir}" >&2
   else
@@ -1242,6 +1254,7 @@ getCode()
     printError "ZOPEN_TYPE should be one of GIT or TARBALL"
     return 4
   fi
+
 }
 
 create_fifo_pipe()

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -382,7 +382,6 @@ processOptions()
   noInstallRuntimeDeps=false
   instrument=false
   printSourceDir=false
-  noInfoMessages=false
   depsDepth=2
   while [ $# -gt 0 ]; do
     case $1 in

--- a/include/common.sh
+++ b/include/common.sh
@@ -874,7 +874,7 @@ printVerbose()
 
 printHeader()
 {
-  if $noInfoMessages; then
+  if [ -n "$noInfoMessages" ]; then
     return 0;
   fi
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
@@ -1041,7 +1041,7 @@ printWarning()
 
 printInfo()
 {
-  if $noInfoMessages; then
+  if [ -n "$noInfoMessages" ]; then
     return 0;
   fi
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""

--- a/include/common.sh
+++ b/include/common.sh
@@ -874,6 +874,9 @@ printVerbose()
 
 printHeader()
 {
+  if $noInfoMessages; then
+    return 0;
+  fi
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   printColors "${NC}${HEADERCOLOR}${BOLD}${UNDERLINE}${1}${NC}"
   [ ! -z "${xtrc}" ] && set -x
@@ -1038,6 +1041,9 @@ printWarning()
 
 printInfo()
 {
+  if $noInfoMessages; then
+    return 0;
+  fi
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   printColors "$1"
   [ -n "${xtrc}" ] && set -x


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
zopen build --print-source-dir  will print the source directory based on the buildenv configuration. This will be used by CI/CD tooling.
```
bashport $ zopen build --print-source-dir
bash-5.2.37

gitport $ zopen build --print-source-dir
git
```

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
