### PR TITLE
Attempt a 3 way patch merge if patch fails to merge

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1175,6 +1175,7 @@ applyPatches()
     printWarning "No patches in ${patch_dir} to apply"
     return 0
   fi
+
   results=$( (cd "${code_dir}" && git status --porcelain --untracked-files=no 2>&1))
   failedcount=0
   if [ "${results}" != '' ]; then
@@ -1195,18 +1196,33 @@ applyPatches()
           (cd "${code_dir}" && git apply --reject "${p}" 2>&1)
         else
           if ! out=$( (cd "${code_dir}" && git apply --check "${p}" 2>&1 && git apply "${p}" 2>&1)); then
-            printSoftError "Patch of make tree failed (${p})."
+            printWarning "Initial patch failed: ${p}"
             printSoftError "${out}"
-            failedcount=$((failedcount + 1))
-            break
+
+            # Check if repo is shallow
+            if (cd "${code_dir}" && git rev-parse --is-shallow-repository) | grep -q true; then
+              printInfo "Repository is shallow, attempting to unshallow..."
+              (cd "${code_dir}" && git fetch --unshallow)
+            fi
+
+            # Retry with 3way
+            if ! out=$( (cd "${code_dir}" && git apply --3way --ignore-space-change "${p}" 2>&1)); then
+              printSoftError "3way patch attempt failed: ${p}"
+              printSoftError "${out}"
+              failedcount=$((failedcount + 1))
+              break
+            else
+              printInfo "Patch applied with 3way merge: ${p}"
+            fi
           fi
         fi
       fi
     done
   fi
 
-  # Tag the files that were just updated (again) as ASCII (hopefully can remove after we build our own git)
+  # Tag updated files as ASCII (ISO8859-1)
   (cd "${code_dir}" && git status --untracked-files -s | awk '{ $1=""; print; }' | xargs -I {} chtag -tcISO8859-1 {})
+
   if ${moved}; then
     mv "${code_dir}/.git" "${code_dir}/.git-for-patches" || exit 99
   fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
The 3 way merge requires the history, and since we now do a shallow clone by default, we use it only in the event that the initial patch merge fails.

I have tried this with perlport, which currently has a patch conflict, but with 3 way the patch conflict goes away.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
