### PR TITLE
Add check for 2.5 LE PTF

### DIFF
--- a/include/prereq.sh
+++ b/include/prereq.sh
@@ -54,6 +54,11 @@ zos31() {
 
 zos25() {
   check_zos_version 2.5
+  if [ ! -f /usr/include/sys/epoll.h ] || [ ! -f /usr/include/sys/eventfd.h ]; then
+    echo "WARNING: Missing LE PTFs UJ94587 UJ94590. You may not have the required Language Environment APAR installed."
+    echo "See: https://www.ibm.com/support/pages/apar/OA61972"
+    echo "To resolve this, install the appropriate PTF for OA61972 on z/OS 2.5."
+  fi
 }
 
 zos24() {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
We are planning to depend on the latest 2.5 PTF. This adds a warning to inform users to install the latest PTF if they do not have it.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
