### PR TITLE
Add meta as an implicit runtime dependency

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2221,6 +2221,10 @@ resolveCommands()
     unset ZOPEN_BOOTSTRAP_CMD
   fi
 
+  # Add meta as an implicit runtime dependency
+  # TODO: remove this once zopen-install is updated to handle this 
+  export ZOPEN_RUNTIME_DEPS="${ZOPEN_RUNTIME_DEPS} meta"
+
   if [ -z "${ZOPEN_CONFIGURE_OPTS}" ]; then
     case "${ZOPEN_CONFIGURE}" in
     *cmake*)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
Before we migrate to the new improved installer, we want to force an update to the latest stable version of meta. This adds meta as a runtime dependency to all subsequent builds with the hopes that when users pick up the latest tools, they will also auto-update meta.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
