### PR TITLE
Add "Did you mean?" suggestions for typos

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -60,12 +60,12 @@ verifySignatureOfPax()
      printError "Failed to extract 'pax' from ${metadataFile}" >&2
   fi
 
-  if ! SIGNATURE=$(jq -e -r '.product.signature' "${metadataFile}"); then 
+  if ! SIGNATURE=$(jq -e -r '.product.signature' "${metadataFile}"); then
     printVerbose "Failed to extract 'signature' from ${metadataFile}" >&2
     return
   fi
 
-  if ! PUBLIC_KEY=$(jq -e -r '.product.public_key' "${metadataFile}"); then 
+  if ! PUBLIC_KEY=$(jq -e -r '.product.public_key' "${metadataFile}"); then
      printError "Failed to extract 'public_key' from ${metadataFile}" >&2
   fi
 
@@ -847,6 +847,7 @@ if ${all}; then
 else
   chosenRepos=$(strtrim "${chosenRepos}")
   invalidlist=""
+  suggestionlist=""
   for chosenRepo in $(echo "${chosenRepos}" | tr ',' ' ' | tr -s ' '); do
     printVerbose "Processing repo: ${chosenRepo}"
     printVerbose "Stripping any version (%), tag (#) or port suffixes"
@@ -859,13 +860,22 @@ else
       chosenRepos=$(echo "${chosenRepos}" | sed -e "s#^${chosenRepo}\$##")
     else
       invalidlist=$(/bin/printf "%s %s" "${invalidlist}" "${chosenRepo}")
+      suggestion=$(findSuggestion "${toolrepo}" "${repo_results}")
+      if [ -n "${suggestion}" ]; then
+        suggestionlist="${suggestionlist}\n> Did you mean to install '${suggestion}'?"
+      fi
     fi
   done
 fi
 
 printVerbose "Checking whether any invalid ports were specified."
 if [ -n "${invalidlist}" ]; then
-  printSoftError "The following requested port(s) do not exist:\n\t$(echo "${invalidlist}" | tr -s '[:space:]')"
+  # Format invalid ports onto new lines for readability
+  printSoftError "The following requested port(s) do not exist:$(echo "${invalidlist}" | tr ' ' '\n\t')"
+  if [ -n "${suggestionlist}" ]; then
+    # Use echo to print suggestions without the printSoftError prefix for cleaner output
+    echo -e "${suggestionlist}" >&2
+  fi
   printError "Check port name(s), remove any port suffixes and retry command."
 fi
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
This PR improves the user experience for the zopen install command by adding a "Did you mean...?" suggestion feature.

Currently, if a user misspells a package name, the script exits with a "port not found" error, forcing the user to manually find the correct name. This change introduces a mechanism to suggest a correction for common typos.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
