### PR TITLE
fix(darkmode): make markdown tables and code blocks readable in dark …

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -2,30 +2,31 @@
   --toc-width: 20rem;
 }
 
-.sidebar-nav>ul>li>ul>li>ul>li.active>a:before {
+.sidebar-nav > ul > li > ul > li > ul > li.active > a:before {
   content: none;
   color: none;
 }
 
-.sidebar-nav>ul>li>ul>li>ul>li>a:before {
+.sidebar-nav > ul > li > ul > li > ul > li > a:before {
   content: none;
   margin: none;
   color: none;
 }
 
-.sidebar-nav li.active>a[href^="#/"]:not([href*="?id="]):not(:only-child) {
-    background-image: none;
-    background-position: none;
-}
-.sidebar-nav li>a[href^="#/"]:not([href*="?id="]):not(:only-child) {
-    background-image: none;
-    background-position: none;
-}
-.sidebar-nav li>a[href^="#/"]:not([href*="?id="]):only-child {
+.sidebar-nav li.active > a[href^="#/"]:not([href*="?id="]):not(:only-child) {
   background-image: none;
   background-position: none;
 }
-.sidebar-nav li>a[href^="#/"]:not([href*="?id="]), .sidebar-nav li>a[href^="#/"]:not([href*="?id="]) ~ ul a {
+.sidebar-nav li > a[href^="#/"]:not([href*="?id="]):not(:only-child) {
+  background-image: none;
+  background-position: none;
+}
+.sidebar-nav li > a[href^="#/"]:not([href*="?id="]):only-child {
+  background-image: none;
+  background-position: none;
+}
+.sidebar-nav li > a[href^="#/"]:not([href*="?id="]),
+.sidebar-nav li > a[href^="#/"]:not([href*="?id="]) ~ ul a {
   padding: 1px;
 }
 
@@ -37,7 +38,7 @@
 }
 
 .page_toc {
-  border-left-color: var(--base-color, rgba(0,0,0,0.07))
+  border-left-color: var(--base-color, rgba(0, 0, 0, 0.07));
 }
 
 #docsify-darklight-theme {
@@ -62,11 +63,12 @@
   display: grid;
   /* Define your columns. Adjust widths as needed.
      Order: Name | Status | Test | Release | Description */
-  grid-template-columns: minmax(140px, 1.5fr) /* Name */
-                         minmax(100px, 0.8fr) /* Status */
-                         minmax(90px, 0.7fr)  /* Test */
-                         minmax(180px, 1.2fr) /* Release */
-                         minmax(200px, 2fr);  /* Description */
+  grid-template-columns:
+    minmax(140px, 1.5fr) /* Name */
+    minmax(100px, 0.8fr) /* Status */
+    minmax(90px, 0.7fr) /* Test */
+    minmax(180px, 1.2fr) /* Release */
+    minmax(200px, 2fr); /* Description */
   gap: 0px 12px; /* No row gap, 12px column gap for spacing between "cells" */
   align-items: baseline; /* Aligns text nicely if some items wrap within their cell */
   font-size: 0.9em; /* Overall smaller font for the details line */
@@ -75,9 +77,9 @@
 
 /* Style for individual "cells" in the grid */
 .tool-info-grid > div {
-  overflow: hidden;         /* Hide overflow */
-  text-overflow: ellipsis;  /* Add ... for overflowed text */
-  white-space: nowrap;      /* Keep text on a single line to trigger ellipsis */
+  overflow: hidden; /* Hide overflow */
+  text-overflow: ellipsis; /* Add ... for overflowed text */
+  white-space: nowrap; /* Keep text on a single line to trigger ellipsis */
 }
 
 /* Allow Name and Description to wrap if needed, overriding nowrap */
@@ -109,4 +111,22 @@
 }
 .tool-item-filterable:nth-child(odd) {
   background-color: #ffffff; /* Or transparent, if your page background isn't white */
+}
+
+@media (prefers-color-scheme: dark) {
+  .markdown-section table,
+  .markdown-section th,
+  .markdown-section td,
+  .markdown-section pre,
+  .markdown-section code {
+    color: #eee !important;
+    background-color: transparent !important;
+  }
+
+  .tool-item-filterable:nth-child(even) {
+    background-color: rgba(255, 255, 255, 0.05) !important;
+  }
+  .tool-item-filterable:nth-child(odd) {
+    background-color: rgba(255, 255, 255, 0.02) !important;
+  }
 }


### PR DESCRIPTION
…theme

<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [x] Ensure all tests pass locally.
- [x] Add tests for any new functionality.
- [x] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [ ] zopen package manager
- [x] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
- Previously, table cells and code/pre blocks in markdown pages (e.g., Latest.md) were using light text on light backgrounds in dark mode, making them invisible.
- This change adds CSS overrides in `styles.css` to:
   - Use lighter text colors for tables, table headers/cells, and code/pre blocks in dark mode
   - Remove forced light backgrounds so the dark theme background is visible
   - Adjust zebra striping for `.tool-item-filterable` rows in dark mode for readability

- Outcome: 
<img width="1710" height="986" alt="Screenshot 2025-08-13 at 11 54 25 PM" src="https://github.com/user-attachments/assets/f03cd792-cf73-45b1-931c-7a64394da9ef" />


No functional changes to Docsify configuration.

## Related Issues

- Related Issue #1057
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
