### PR TITLE
Remove zoslib_hook.o hardcoded link

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1531,19 +1531,23 @@ replaceHardcodedPath()
   f=$3
   hasHardcodedPaths=true
   printVerbose "Replacing ${orig} in ${f}"
-  # only substitute text
-  if /bin/sed -e "" ${f} 2> /dev/null 1>&2; then
+  # only substitute text files
+  if /bin/sed -e "" "${f}" 2> /dev/null 1>&2; then
     isWritable=true
     if [ ! -w "${f}" ]; then
-      isWriteable=false
-      chmod "+w" ${f}
+      isWritable=false
+      chmod "+w" "${f}"
     fi
-    cp ${f} ${f}.old &&
-      # replace hardcoded path and strip out the -suffix in name to match active
-      sed -e "s#${orig}/\([^/]\+\)/[^/\n '\";]*#${replaced}/\1/\1#g" ${f}.old > ${f} &&
-      rm ${f}.old
-    if ! ${isWriteable}; then
-      chmod "-w" ${f}
+
+    cp "${f}" "${f}.old" &&
+      sed \
+        -e "s#${orig}/\([^/]\+\)/[^/\n '\";]*#${replaced}/\1/\1#g" \
+        -e "s#${ZOSLIB_HOOK_OBJ}##g" \
+        "${f}.old" > "${f}" &&
+      rm "${f}.old"
+
+    if ! ${isWritable}; then
+      chmod "-w" "${f}"
     fi
   fi
 }
@@ -2615,6 +2619,7 @@ zz
   # Apply it in both LIB envars because some ports use ZOPEN_EXTRA_LIBS directly
   export ZOPEN_EXTRA_LIBS="${ZOPEN_EXTRA_LIBS} ${PWD}/${output}.o"
   export LIBS="${LIBS} ${PWD}/${output}.o"
+  export ZOSLIB_HOOK_OBJ="${PWD}/${output}.o"
 
   cd "${prevpath}" || printError "Could not change back to the original path ${prevpath}"
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
Some tools like ncurses has hardcoded zoslib hook object as library dependency. This fix removes it

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
