### PR TITLE
Skip GenerateZOSLIBHooks for BARE build type

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2507,6 +2507,11 @@ generateZOSLIBHooks()
   #LIBPATH|prepend|PROJECT_ROOT/lib
   #"
 
+  if [ "${ZOPEN_TYPE}x" = "BAREx" ]; then
+    printVerbose "Skipping GenerateZOSLIBHooks for BARE build type"
+    return
+  fi
+
   if [ -z "${CC}" ]; then
     printVerbose "Skipping GenerateZOSLIBHooks since CC is not set"
     return


### PR DESCRIPTION
Added a condition to skip GenerateZOSLIBHooks for BARE build type.

<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
Skip GenerateZOSLIBHooks for BARE build type as no build is invoked.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
