### PR TITLE
Fix variable escaping in writeConfigFile

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -262,7 +262,7 @@ export ZOPEN_ROOTFS
 
 # When running under Gemini or Bob shell, stderr output is garbled.
 # Redirect messages to stdout instead.
-if [ -n "${BOBSHELL_CLI}" ] || [ -n "${GEMINI_CLI}" ]; then
+if [ -n "\${BOBSHELL_CLI}" ] || [ -n "\${GEMINI_CLI}" ]; then
   ZOPEN_STDERR_TO_STDOUT=true
 else
   ZOPEN_STDERR_TO_STDOUT=false
@@ -275,7 +275,7 @@ else
   if [ "\${CUR_CVT}" = "ON" ] || [ "\${CUR_CVT}" = "ALL" ]; then
     : # ok - we can source the config with these settings
   else
-    if ${ZOPEN_STDERR_TO_STDOUT}; then
+    if \${ZOPEN_STDERR_TO_STDOUT}; then
       echo "Error. You have _BPXK_AUTOCVT=\${CUR_CVT} and we can not source the configuration."
     else
       echo "Error. You have _BPXK_AUTOCVT=\${CUR_CVT} and we can not source the configuration." >&2


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
Fix variable escaping in writeConfigFile. This fixes zopen-config sourcing issue

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
