### PR TITLE
Add support for CLANG_WRAPPER

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -848,6 +848,12 @@ PYENVEOF
     ZOPEN_DEPS="${implicitDeps} ${langDeps} ${ZOPEN_DEPS}"
   fi
 
+  # Handle USE_CLANG_WRAPPER: replace check_clang and zoslib with clang_zos_wrapper
+  if [ -n "${USE_CLANG_WRAPPER}" ]; then
+    ZOPEN_DEPS=$(echo "${ZOPEN_DEPS}" | sed 's/\bcheck_clang\b//g' | sed 's/\bzoslib\b//g' | xargs)
+    ZOPEN_DEPS="${ZOPEN_DEPS} clang_zos_wrapper"
+  fi
+
   # Add meta as an implicit runtime dependency
   # TODO: remove this once zopen-install is updated to handle this
   export ZOPEN_RUNTIME_DEPS="${ZOPEN_RUNTIME_DEPS} meta"


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [x] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
Add support for using clang_zos_wrapper(https://github.com/zopencommunity/clang_zos_wrapperport) which wraps clang along with zoslib. This is required to build libgpgerror, libgcrypt.

To use clang wrapper in the tools, add "export USE_CLANG_WRAPPER=1" in buildenv.

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
