### PR TITLE
Improve robustness of temporary directory identification

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -13,12 +13,12 @@ zopenInitialize()
   
   # Temporary files
   for zopen_tmp_dir in "${TMPDIR}" "${TMP}" /tmp; do
-    if [ ! -z ${zopen_tmp_dir} ] && [ -d ${zopen_tmp_dir} ]; then
+    if [ -n "${zopen_tmp_dir}" ] && [ -d "${zopen_tmp_dir}/." ]; then
       break
     fi
   done
   
-  if [ ! -d "${zopen_tmp_dir}" ]; then
+  if [ ! -d "${zopen_tmp_dir}/." ]; then
     printError "Temporary directory not found. Please specify \$TMPDIR, \$TMP or have a valid /tmp directory."
   fi
 
@@ -168,9 +168,9 @@ mktempfile()
   suffix=".tmp"
   [ -n "$2" ] && [ ! "$2" = "." ] && suffix="$2"
   for tmp in "${TMPDIR}" "${TMP}" /tmp; do
-    [ -n "${tmp}" ] && [ -d "${tmp}" ] && break
+    [ -n "${tmp}" ] && [ -d "${tmp}/." ] && break
   done
-  [ ! -d "${tmp}" ] && printError "Could not locate suitable temporary directory [tried \$TMPDIR \$TMP & /tmp]. Define a temporary location and retry command"
+  [ ! -d "${tmp}/." ] && printError "Could not locate suitable temporary directory [tried \$TMPDIR \$TMP & /tmp]. Define a temporary location and retry command"
   rnd=$(od -vAn -tu8 -N8  < /dev/urandom | tr -d "[:blank:]")
   tempfile="${tmp}/${prefix%%_}_${rnd}.${suffix##.}"
   if [ -e  "${tempfile}" ]; then

--- a/include/common.sh
+++ b/include/common.sh
@@ -13,12 +13,15 @@ zopenInitialize()
   
   # Temporary files
   for zopen_tmp_dir in "${TMPDIR}" "${TMP}" /tmp; do
-    if [ -n "${zopen_tmp_dir}" ] && [ -d "${zopen_tmp_dir}/." ]; then
+    [ -z "${zopen_tmp_dir}" ] && continue
+    # Remove trailing slashes to avoid issues with some shells/filesystems
+    zopen_tmp_dir=$(echo "${zopen_tmp_dir}" | /bin/sed 's#/*$##')
+    if [ -d "${zopen_tmp_dir}" ] || [ -d "${zopen_tmp_dir}/." ]; then
       break
     fi
   done
   
-  if [ ! -d "${zopen_tmp_dir}/." ]; then
+  if [ ! -d "${zopen_tmp_dir}" ] && [ ! -d "${zopen_tmp_dir}/." ]; then
     printError "Temporary directory not found. Please specify \$TMPDIR, \$TMP or have a valid /tmp directory."
   fi
 
@@ -168,9 +171,15 @@ mktempfile()
   suffix=".tmp"
   [ -n "$2" ] && [ ! "$2" = "." ] && suffix="$2"
   for tmp in "${TMPDIR}" "${TMP}" /tmp; do
-    [ -n "${tmp}" ] && [ -d "${tmp}/." ] && break
+    [ -z "${tmp}" ] && continue
+    tmp=$(echo "${tmp}" | /bin/sed 's#/*$##')
+    if [ -d "${tmp}" ] || [ -d "${tmp}/." ]; then
+      break
+    fi
   done
-  [ ! -d "${tmp}/." ] && printError "Could not locate suitable temporary directory [tried \$TMPDIR \$TMP & /tmp]. Define a temporary location and retry command"
+  if [ ! -d "${tmp}" ] && [ ! -d "${tmp}/." ]; then
+    printError "Could not locate suitable temporary directory [tried \$TMPDIR \$TMP & /tmp]. Define a temporary location and retry command"
+  fi
   rnd=$(od -vAn -tu8 -N8  < /dev/urandom | tr -d "[:blank:]")
   tempfile="${tmp}/${prefix%%_}_${rnd}.${suffix##.}"
   if [ -e  "${tempfile}" ]; then


### PR DESCRIPTION
Problem
  Users on newer z/OS systems (specifically z/OS 3.2) reported that zopen init fails to identify a valid temporary
  directory, even when /tmp exists or TMPDIR is explicitly set. Analysis revealed two primary causes:

   1. Dynamic Symlink Resolution: On many z/OS systems, /tmp is a symbolic link to $SYSNAME/tmp. Standard shell tests
      like [ -d /tmp ] often fail to resolve the $SYSNAME symbol in non-interactive script contexts, leading the script
      to believe the directory doesn't exist.
   2. Unquoted Variable Logic Bug: In the original loop for zopen_tmp_dir in "${TMPDIR}" "${TMP}" /tmp, if an environment
      variable like TMP is unset, the unquoted test evaluates as [ -d ] (missing argument). On some z/OS shells, this
      incorrectly returns true, causing the loop to break with an empty string, which subsequently fails the final
      validation.
   3. Trailing Slash Sensitivity: Trailing slashes in TMPDIR were found to occasionally interfere with path resolution or
      the /. resolution trick on specific z/OS filesystem configurations.

  Solution
  This PR implements a hardened temporary directory identification strategy in include/common.sh:

   - Path Normalization: Uses sed to strip all trailing slashes from candidate paths, ensuring consistent behavior
     regardless of user input.
   - Dual Validation (The "Dot" Trick): Validates paths using both [ -d path ] and [ -d path/. ]. Appending /. forces a
     directory lookup that correctly triggers the resolution of dynamic symbolic links and system symbols.
   - Strict Variable Quoting: All tests now use quoted variables (e.g., [ -d "${tmp}" ]) to prevent the shell from
     misinterpreting empty or missing arguments.
   - Empty Candidate Skipping: Explicitly continues the loop if a candidate variable is empty, preventing the "empty
     break" bug.
