### PR TITLE
feat: add GENERATE_PAX_RPM parameter to control pax/rpm generation

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -86,7 +86,7 @@ jobs:
           ENCODED_CAUSE=$(echo -n "$CAUSE" | jq -s -R -r @uri)
           JENKINS_JOB_URL="${{ vars.JENKINS_HOST_URL }}/job/Port-Build/buildWithParameters?token=jenkinstest&cause=${ENCODED_CAUSE}"
 
-          RESPONSE=$(curl -k -X POST -s -i -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" "${JENKINS_JOB_URL}" -F PORT_GITHUB_REPO="${repo}" -F PORT_DESCRIPTION="Github CI Test of ${repo}" -F PORT_BRANCH="${branch}" ${SOURCE_URL_OPT} ${BUILD_BRANCH_OPT})
+          RESPONSE=$(curl -k -X POST -s -i -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" "${JENKINS_JOB_URL}" -F PORT_GITHUB_REPO="${repo}" -F PORT_DESCRIPTION="Github CI Test of ${repo}" -F PORT_BRANCH="${branch}" -F GENERATE_PAX_RPM=false ${SOURCE_URL_OPT} ${BUILD_BRANCH_OPT})
 
           # Extract the build URL from the response headers
           BUILD_URL=$(echo "$RESPONSE" | grep -oP "location: \K(.*)" | tr -d '\r')

--- a/cicd/build.groovy
+++ b/cicd/build.groovy
@@ -8,6 +8,7 @@
 #   - PORT_SOURCE_URL : optional alternate source URL passed through to zopen-build as ZOPEN_SOURCE_URL
 #   - BUILD_LINE: dev or stable
 #   - FORCE_CLANG : Build using clang
+#   - GENERATE_PAX_RPM : (default: true) Generate pax and RPM packages. Set to false to skip -gr -sp options
 # Output:
 #   - pax.Z artifact is published as a Jenkins artifact
 #   - package is copied to /jenkins/build on z/OS zot system
@@ -58,8 +59,14 @@ if [ ! -z "$PORT_SOURCE_URL" ]; then
 fi
 git clone -b "${PORT_BRANCH}" "${PORT_GITHUB_REPO}" ${PORT_NAME} && cd ${PORT_NAME}
 
-# Always run tests and update dependencies and generate pax file
-zopen build -v -b release -u -gr -sp --no-set-active $extraOptions
+# Conditionally add -gr -sp options based on GENERATE_PAX_RPM parameter
+paxRpmOptions="-gr -sp"
+if [ "${GENERATE_PAX_RPM}" = "false" ]; then
+  paxRpmOptions=""
+fi
+
+# Always run tests and update dependencies
+zopen build -v -b release -u $paxRpmOptions --no-set-active $extraOptions
 
 # Clean the cache after build is complete
 zopen clean -c -v

--- a/cicd/pipeline.jenkins
+++ b/cicd/pipeline.jenkins
@@ -4,6 +4,7 @@
 //   PORT_DESCRIPTION : Description of the project
 //   BUILD_LINE: dev or stable line to build against (default: stable)
 //   FORCE_CLANG : Boolean to enforce building with Clang vs xlclang
+//   GENERATE_PAX_RPM : Boolean to generate pax/RPM artifacts (default: true)
 //   NO_PROMOTE : Boolean, if true, avoid promotion
 //   NODE_LABEL : A label for the node to build on, default is "zos"
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
@@ -31,6 +32,7 @@ node('linux')
                    string(name: 'PORT_BRANCH', value: "${branch}"),
                    string(name: 'node', value: "${node_label}"),
                    booleanParam(name: 'FORCE_CLANG', value: params.FORCE_CLANG),
+                   booleanParam(name: 'GENERATE_PAX_RPM', value: true),
                    string(name: 'BUILD_LINE', value: "${build_line}"),
                    ]
     def result = buildResult.getResult()


### PR DESCRIPTION
- Skip -gr -sp options to not generate PAX/RPM's
- Set to true in GitHub Actions CI to speed up tests
- Defaults to false in Jenkins builds

<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [x] CI/CD
- [ ] Tools

## Description
add TEST_BUILD parameter to control pax/rpm generation. This avoids building pax for test builds

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
