### PR TITLE
add automated RPM signing

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -402,7 +402,8 @@ Option:
   --oci                 build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY.
   -s                    exec a shell before running configure. Useful when
                         manually building ports.
-  --sign-pax, -sp       This option signs the pax file.
+  --sign-pax, --sign-package, -sp
+                        This option signs the pax file.
 			ZOPEN_GPG_SECRET_KEY_FILE, ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE
                         and ZOPEN_GPG_PUBLIC_KEY_FILE must be set for signing the file.
   -v                    run in verbose mode.
@@ -442,7 +443,7 @@ processOptions()
   generatePax=false
   generateRPM=false
   setActive=true
-  signPax=false
+  signPackage=false
   forcePatchApply=false
   depsPath="${ZOPEN_PKGINSTALL}"
   forceUpgradeDeps=false
@@ -549,8 +550,8 @@ processOptions()
     "-s" | "--shell")
       startShell=true
       ;;
-    "-sp" | "--sign-pax")
-      signPax=true
+    "-sp" | "--sign-pax" | "--sign-package")
+      signPackage=true
       generatePax=true
       ;;
     *)
@@ -2514,6 +2515,9 @@ create_rpm()
     if [ -n "${rpm_deps}" ]; then
       cmd="${cmd} --requires \"${rpm_deps}\""
     fi
+    if [ "${signPackage}" = "true" ]; then
+      cmd="${cmd} --sign"
+    fi
     if ! runAndLog "${cmd}"; then
       printError "Could not generate RPM from \"${paxFileName}\""
     fi
@@ -2527,8 +2531,8 @@ finalize_pax_metadata()
   pax_size=$(getPathSizeInBytes "${paxFileName}")
   md5sum=$(md5sum "${paxFileName}" | awk '{print $1}')
 
-  #If signPax is true, rest of variables check is done before setDepsEnv
-  if [ "${signPax}" = "true" ]; then
+  #If signPackage is true, rest of variables check is done before setDepsEnv
+  if [ "${signPackage}" = "true" ]; then
     signPaxFile
     public_key=$(jq -Rs . < ${ZOPEN_GPG_PUBLIC_KEY_FILE})
   fi
@@ -2553,8 +2557,8 @@ package()
   if [ -n "${ZOPEN_INSTALL_CMD}" ]; then
     #TODO: Hack so that we can use coreutils md5sum without impacting builds
     ZOPEN_DEPS="coreutils jq"
-    if [ "${signPax}" = "true" ] && ( [ -z "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ -z "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] || [ -z "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] || [ ! -r "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] ); then
-      printError "GPG keyring environment variables are not set! You can omit the --sign-pax option to bypass this"
+    if [ "${signPackage}" = "true" ] && ( [ -z "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ -z "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] || [ -z "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] || [ ! -r "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] ); then
+      printError "GPG keyring environment variables are not set! You can omit the --sign-pax/--sign-package option to bypass this"
     else
       ZOPEN_DEPS="${ZOPEN_DEPS} gpg"
     fi

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -402,10 +402,12 @@ Option:
   --oci                 build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY.
   -s                    exec a shell before running configure. Useful when
                         manually building ports.
-  --sign-pax, --sign-package, -sp
-                        This option signs the pax file.
+  --sign-pax, -sp       This option signs the pax file.
 			ZOPEN_GPG_SECRET_KEY_FILE, ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE
                         and ZOPEN_GPG_PUBLIC_KEY_FILE must be set for signing the file.
+  --sign-rpm, -sr       This option signs the RPM package.
+			ZOPEN_GPG_SECRET_KEY_FILE and ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE
+                        must be set for signing the RPM.
   -v                    run in verbose mode.
   -vv                   run in very verbose mode (sets environment variables
                         V=1 and VERBOSE=1).
@@ -443,7 +445,8 @@ processOptions()
   generatePax=false
   generateRPM=false
   setActive=true
-  signPackage=false
+  signPax=false
+  signRPM=false
   forcePatchApply=false
   depsPath="${ZOPEN_PKGINSTALL}"
   forceUpgradeDeps=false
@@ -550,8 +553,13 @@ processOptions()
     "-s" | "--shell")
       startShell=true
       ;;
-    "-sp" | "--sign-pax" | "--sign-package")
-      signPackage=true
+    "-sp" | "--sign-pax")
+      signPax=true
+      generatePax=true
+      ;;
+    "-sr" | "--sign-rpm")
+      signRPM=true
+      generateRPM=true
       generatePax=true
       ;;
     *)
@@ -2515,7 +2523,7 @@ create_rpm()
     if [ -n "${rpm_deps}" ]; then
       cmd="${cmd} --requires \"${rpm_deps}\""
     fi
-    if [ "${signPackage}" = "true" ]; then
+    if [ "${signRPM}" = "true" ]; then
       cmd="${cmd} --sign"
     fi
     if ! runAndLog "${cmd}"; then
@@ -2531,8 +2539,8 @@ finalize_pax_metadata()
   pax_size=$(getPathSizeInBytes "${paxFileName}")
   md5sum=$(md5sum "${paxFileName}" | awk '{print $1}')
 
-  #If signPackage is true, rest of variables check is done before setDepsEnv
-  if [ "${signPackage}" = "true" ]; then
+  #If signPax is true, rest of variables check is done before setDepsEnv
+  if [ "${signPax}" = "true" ]; then
     signPaxFile
     public_key=$(jq -Rs . < ${ZOPEN_GPG_PUBLIC_KEY_FILE})
   fi
@@ -2557,9 +2565,13 @@ package()
   if [ -n "${ZOPEN_INSTALL_CMD}" ]; then
     #TODO: Hack so that we can use coreutils md5sum without impacting builds
     ZOPEN_DEPS="coreutils jq"
-    if [ "${signPackage}" = "true" ] && ( [ -z "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ -z "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] || [ -z "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] || [ ! -r "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] ); then
-      printError "GPG keyring environment variables are not set! You can omit the --sign-pax/--sign-package option to bypass this"
-    else
+    if [ "${signPax}" = "true" ] || [ "${signRPM}" = "true" ]; then
+      if ( [ -z "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ -z "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] ); then
+        printError "GPG keyring environment variables are not set! You can omit the --sign-pax or --sign-rpm option to bypass this"
+      fi
+      if [ "${signPax}" = "true" ] && ( [ -z "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] ); then
+        printError "ZOPEN_GPG_PUBLIC_KEY_FILE not set or not readable! Required for PAX signing."
+      fi
       ZOPEN_DEPS="${ZOPEN_DEPS} gpg"
     fi
 

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -1029,7 +1029,12 @@ main() {
     # Build RPM if requested
     if [ "$BUILD_RPM" = true ]; then
         if build_rpm "$OUTPUT_FILE" "$PAX_FILE" "$BUILDROOT"; then
+            echo ""
+            echo "=========================================="
+            echo "RPM Build Complete!"
             echo "RPM package built successfully!"
+            echo "=========================================="
+            echo ""
         else
             echo "Warning: RPM build failed. Please review the spec file and try again." >&2
             exit 1

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -40,6 +40,7 @@ PACKAGER_EMAIL="${CURRENT_USER}@$(hostname 2>/dev/null || echo "localhost")"
 # Build flag
 BUILD_RPM=false
 BUILD_BINARY_ONLY=false
+SIGN_RPM=false
 BUILDROOT="${HOME}/rpmbuild"
 VALIDATE_SPEC=false
 DRY_RUN=false
@@ -386,6 +387,103 @@ EOF
     return 0
 }
 
+# Function to sign generated RPMs
+sign_rpm() {
+    buildroot="$1"
+    
+    # Check for required environment variables
+    if [ -z "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ -z "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ]; then
+        printError "Signing requested but ZOPEN_GPG_SECRET_KEY_FILE or ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE not set"
+        return 1
+    fi
+
+    echo ""
+    echo "=========================================="
+    echo "Signing RPM packages..."
+    echo "=========================================="
+    echo ""
+
+    # Create a temporary directory for GPG keyring using zopen_tmp_dir
+    if [ -z "${zopen_tmp_dir}" ] || [ ! -d "${zopen_tmp_dir}" ]; then
+        printError "zopen_tmp_dir not set or not a directory. Cannot create temporary GPG directory."
+    fi
+    TMP_GPG_DIR="${zopen_tmp_dir}/rpm_gpg_$$"
+    echo "Creating temporary GPG directory: ${TMP_GPG_DIR}"
+    if ! mkdir -p "${TMP_GPG_DIR}" 2>/dev/null; then
+        printError "Failed to create temporary directory for GPG signing"
+    fi
+    chmod 700 "${TMP_GPG_DIR}"
+    echo "Temporary GPG directory created"
+    
+    # Register cleanup trap
+    addCleanupTrapCmd "rm -rf ${TMP_GPG_DIR}"
+    echo "Cleanup trap registered"
+    
+    OLD_GNUPGHOME="$GNUPGHOME"
+    export GNUPGHOME="$TMP_GPG_DIR"
+    echo "GNUPGHOME set to: ${GNUPGHOME}"
+    RPM_LIST=""
+
+    # Import the private key
+    echo "Importing private key..."
+    if ! gpg --batch --yes --import "${ZOPEN_GPG_SECRET_KEY_FILE}" >/dev/null 2>&1; then
+        printError "Failed to import GPG secret key"
+    fi
+    echo "Private key imported successfully"
+
+    # Identify the GPG key ID (long ID)
+    echo "Extracting GPG key ID..."
+    GPG_KEY_ID=$(gpg --list-secret-keys --with-colons | grep '^sec' | cut -d: -f5 | head -n 1)
+    if [ -z "${GPG_KEY_ID}" ]; then
+        printError "Could not identify GPG key ID from imported key"
+    fi
+    echo "GPG key ID: ${GPG_KEY_ID}"
+
+    # Create a wrapper script for gpg to handle the passphrase file
+    echo "Creating GPG wrapper script..."
+    GPG_WRAPPER="${TMP_GPG_DIR}/gpg_wrapper.sh"
+    cat << EOF > "${GPG_WRAPPER}"
+#!/bin/sh
+gpg --batch --pinentry-mode loopback --passphrase-file "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" "\$@"
+EOF
+    chmod +x "${GPG_WRAPPER}"
+    echo "GPG wrapper script created"
+
+    # Sign the RPMs using the wrapper and key ID
+    # We use --define to override the GPG command and key details
+    SIGN_CMD="rpmsign --addsign --key-id ${GPG_KEY_ID} \
+        --define '_gpg_name ${GPG_KEY_ID}' \
+        --define '__gpg ${GPG_WRAPPER}' \
+        --define '_gpg_path ${TMP_GPG_DIR}'"
+
+    # Use a temporary file to avoid subshell return issues
+    echo "Finding RPM files to sign..."
+    RPM_LIST=$(mktempfile "rpmlist")
+    find "$buildroot/RPMS" -name "*.rpm" -type f > "$RPM_LIST"
+    
+    if [ ! -s "$RPM_LIST" ]; then
+        printError "No RPM packages found to sign in $buildroot/RPMS"
+    fi
+    
+    rpm_count=$(wc -l < "$RPM_LIST")
+    echo "Found ${rpm_count} RPM(s) to sign"
+
+    while read rpm; do
+        [ -z "$rpm" ] && continue
+        echo "Signing $rpm..."
+        if ! eval "${SIGN_CMD} \"${rpm}\""; then
+            printError "Failed to sign RPM: $rpm"
+        fi
+    done < "$RPM_LIST"
+
+    rm -f "$RPM_LIST"
+    rm -rf "$TMP_GPG_DIR"
+    [ -n "$OLD_GNUPGHOME" ] && export GNUPGHOME="$OLD_GNUPGHOME" || unset GNUPGHOME
+
+    echo "All RPMs signed successfully"
+    return 0
+}
+
 # Function to setup rpmbuild directories
 setup_rpmbuild() {
 buildroot="$1"
@@ -718,6 +816,11 @@ source_name=$(basename "$pax_file")
             done
         fi
         echo ""
+
+        if [ "$SIGN_RPM" = true ]; then
+            sign_rpm "$buildroot"
+        fi
+
         return 0
     else
         echo ""
@@ -838,6 +941,10 @@ main() {
             --build-binary)
                 BUILD_RPM=true
                 BUILD_BINARY_ONLY=true
+                shift
+                ;;
+	    --sign)
+                SIGN_RPM=true
                 shift
                 ;;
             --buildroot)

--- a/cicd/build.groovy
+++ b/cicd/build.groovy
@@ -59,8 +59,8 @@ if [ ! -z "$PORT_SOURCE_URL" ]; then
 fi
 git clone -b "${PORT_BRANCH}" "${PORT_GITHUB_REPO}" ${PORT_NAME} && cd ${PORT_NAME}
 
-# Conditionally add -gr -sp options based on GENERATE_PAX_RPM parameter
-paxRpmOptions="-gr -sp"
+# Conditionally add -gp -sp -gr -sr options based on GENERATE_PAX_RPM parameter
+paxRpmOptions="-gp -sp -gr -sr"
 if [ "${GENERATE_PAX_RPM}" = "false" ]; then
   paxRpmOptions=""
 fi

--- a/docs/Guides/ThePackageManager.md
+++ b/docs/Guides/ThePackageManager.md
@@ -147,7 +147,7 @@ The meta package, which include zopen, can be upgraded via the `zopen upgrade` c
 # Signing & verifying using zopen framework
 * `zopen-build` can now generate signed builds, and `zopen-install` can verify the signature before installation.
 
-* We can enable signed builds using the `--sign-pax` or `-sp` option. If this option is set, it reads the **ZOPEN\_GPG\_SECRET\_KEY\_FILE** and its passphrase from **ZOPEN\_GPG\_SECRET\_KEY\_PASSPHRASE_FILE** to sign the file. The public key is read from **ZOPEN_GPG\_PUBLIC\_KEY\_FILE**.
+* We can enable signed builds using the `--sign-pax`, `--sign-package`, or `-sp` option. If this option is set, it reads the **ZOPEN\_GPG\_SECRET\_KEY\_FILE** and its passphrase from **ZOPEN\_GPG\_SECRET\_KEY\_PASSPHRASE_FILE** to sign the file. The public key is read from **ZOPEN_GPG\_PUBLIC\_KEY\_FILE**.
 <br/>These files are mandatory for signing a file.
 
 * The public key and the signed file details are written to metadata.json (this JSON is not part of the PAX).

--- a/docs/Guides/ThePackageManager.md
+++ b/docs/Guides/ThePackageManager.md
@@ -147,7 +147,8 @@ The meta package, which include zopen, can be upgraded via the `zopen upgrade` c
 # Signing & verifying using zopen framework
 * `zopen-build` can now generate signed builds, and `zopen-install` can verify the signature before installation.
 
-* We can enable signed builds using the `--sign-pax`, `--sign-package`, or `-sp` option. If this option is set, it reads the **ZOPEN\_GPG\_SECRET\_KEY\_FILE** and its passphrase from **ZOPEN\_GPG\_SECRET\_KEY\_PASSPHRASE_FILE** to sign the file. The public key is read from **ZOPEN_GPG\_PUBLIC\_KEY\_FILE**.
+* We can enable signed PAX builds using the `--sign-pax` or `-sp` option. If this option is set, it reads the **ZOPEN\_GPG\_SECRET\_KEY\_FILE** and its passphrase from **ZOPEN\_GPG\_SECRET\_KEY\_PASSPHRASE_FILE** to sign the file. The public key is read from **ZOPEN_GPG\_PUBLIC\_KEY\_FILE**.
+* We can enable signed RPM builds using the `--sign-rpm` or `-sr` option. If this option is set, it reads the **ZOPEN\_GPG\_SECRET\_KEY\_FILE** and its passphrase from **ZOPEN\_GPG\_SECRET\_KEY\_PASSPHRASE_FILE** to sign the RPM package.
 <br/>These files are mandatory for signing a file.
 
 * The public key and the signed file details are written to metadata.json (this JSON is not part of the PAX).


### PR DESCRIPTION
- Separate local install from packaging logic in zopen-build.
- Add specialized functions for pax and RPM creation.
- Enable headless RPM signing using zopen GPG environment variables.

Fixes https://github.com/zopencommunity/rpmport/issues/22

<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
