### PR TITLE
Dependency Install skip for Non-Zos

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -915,6 +915,11 @@ PYENVEOF
 
 setDepsEnv()
 {
+  if ${getSourceOnly} && [ "$(uname -s)" != "OS/390" ]; then
+    printVerbose "Skipping dependency installation in --get-source mode and on non-z/OS system"
+    return
+  fi
+
   deps="${ZOPEN_DEPS}"
   orig="${PWD}"
   deps=$(normalizeDeps "${deps}")


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Bug Fix

## Category

- [ ] zopen package manager
- [ ] CI/CD

## Description
Skip Dependency build for get source mode and non zos when zopen build -g is used for building.
