### PR TITLE
normalize version prefixes

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2139,14 +2139,27 @@ getPathSizeInBytes()
 }
 
 #
+# Extract raw version suffix from a package name string (e.g., "curl-v8.10.1" → "v8.10.1")
+# Returns empty string if no version found
+#
+extractRawVersionFromPackage()
+{
+  _erfp_package="$1"
+  _erfp_version=$(echo "$_erfp_package" | sed -E 's/.*-([vV]?[0-9].*)$/\1/')
+  if [ "$_erfp_version" != "$_erfp_package" ] && [ -n "$_erfp_version" ]; then
+    echo "$_erfp_version"
+  fi
+}
+
+#
 # Extract version from a package name string (e.g., "curl-v8.10.1" → "8.10.1")
 # Handles optional v/V prefix and returns empty string if no version found
 #
 extractVersionFromPackage()
 {
   _evfp_package="$1"
-  _evfp_version=$(echo "$_evfp_package" | sed -E 's/.*-([vV]?[0-9].*)$/\1/')
-  if [ "$_evfp_version" != "$_evfp_package" ] && [ -n "$_evfp_version" ]; then
+  _evfp_version=$(extractRawVersionFromPackage "$_evfp_package")
+  if [ -n "$_evfp_version" ]; then
     normalizeVersion "$_evfp_version"
   fi
 }
@@ -2164,11 +2177,11 @@ getProjectName()
     return 0
   fi
 
-  # Intelligent fallback: try to extract version and derive name
-  version=$(extractVersionFromPackage "$package")
-  if [ -n "$version" ]; then
-    # Version was successfully extracted, remove the version segment (including any v/V prefix) to get name
-    echo "$package" | sed -E 's/-[vV]?'"$(echo "$version" | sed 's/[.[\*^$]/\\&/g')"'$//'
+  # Intelligent fallback: try to extract raw version and derive name
+  rawVersion=$(extractRawVersionFromPackage "$package")
+  if [ -n "$rawVersion" ]; then
+    # Remove the raw matched suffix directly from the end using parameter expansion
+    echo "${package%-${rawVersion}}"
   else
     # No version pattern found, return the full package name
     echo "$package"

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2139,6 +2139,19 @@ getPathSizeInBytes()
 }
 
 #
+# Extract version from a package name string (e.g., "curl-v8.10.1" → "8.10.1")
+# Handles optional v/V prefix and returns empty string if no version found
+#
+extractVersionFromPackage()
+{
+  _evfp_package="$1"
+  _evfp_version=$(echo "$_evfp_package" | sed -E 's/.*-([vV]?[0-9].*)$/\1/')
+  if [ "$_evfp_version" != "$_evfp_package" ] && [ -n "$_evfp_version" ]; then
+    normalizeVersion "$_evfp_version"
+  fi
+}
+
+#
 # Extract project name from package name (e.g., xcb-proto-1.17.0 -> xcb-proto)
 # Uses ZOPEN_PROJECT_NAME if set, otherwise intelligently parses package name
 #
@@ -2151,11 +2164,11 @@ getProjectName()
     return 0
   fi
 
-  # Intelligent fallback: try to extract version (handling optional 'v' prefix) and derive name
-  version=$(echo "$package" | sed -E 's/.*-([vV]?[0-9].*)$/\1/')
-  if [ "$version" != "$package" ] && [ -n "$version" ]; then
-    # Version was successfully extracted, remove it to get name
-    echo "${package%-${version}}"
+  # Intelligent fallback: try to extract version and derive name
+  version=$(extractVersionFromPackage "$package")
+  if [ -n "$version" ]; then
+    # Version was successfully extracted, remove the version segment (including any v/V prefix) to get name
+    echo "$package" | sed -E 's/-[vV]?'"$(echo "$version" | sed 's/[.[\*^$]/\\&/g')"'$//'
   else
     # No version pattern found, return the full package name
     echo "$package"
@@ -2172,15 +2185,11 @@ generateMetadataJSON()
   if [ -n "${versionString}" ]; then
     version="${versionString}"
   else
-    # Try to extract version from package name (rightmost segment starting with digit or v/V prefix)
-    version=$(echo "$package" | sed -E 's/.*-([vV]?[0-9].*)$/\1/')
-    if [ "$version" != "$package" ] && [ -n "$version" ]; then
-      # Strip optional v/V prefix for consistency with numeric versioning
-      version="${version#[vV]}"
-    else
+    # Try to extract version from package name (handles optional v/V prefix)
+    version=$(extractVersionFromPackage "$package")
+    if [ -z "$version" ]; then
       # Fallback to the last segment of the package name
-      version=$(echo "${package}" | sed 's/.*-//')
-      version="${version#[vV]}"
+      version=$(normalizeVersion "$(echo "${package}" | sed 's/.*-//')")
     fi
   fi
 
@@ -2464,7 +2473,7 @@ install()
       printError "A zopen_get_version() function must be defined in the buildenv to extract the version contents"
     else
       versionString=$(zopen_get_version)
-      versionString="${versionString#[vV]}"
+      versionString=$(normalizeVersion "$versionString")
       echo ${versionString} | awk -F. '{
         if (NF < 1 || NF > 4) {
           exit 1
@@ -2648,6 +2657,13 @@ resolveCommands()
     fi
   fi
   ZOPEN_PROJECT_HEAD_COMMIT_SHA="$(git rev-parse HEAD)"
+
+  # Normalize ZOPEN_NAME to remove any v/V prefix in the version portion
+  _zn_version=$(extractVersionFromPackage "${ZOPEN_NAME}")
+  if [ -n "${_zn_version}" ]; then
+    _zn_name=$(getProjectName "${ZOPEN_NAME}")
+    ZOPEN_NAME="${_zn_name}-${_zn_version}"
+  fi
 
   # Check if ZOPEN_NAME contains a "-"
   if [ -z "$(echo "${ZOPEN_NAME}" | grep '-')" ]; then

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2194,17 +2194,8 @@ generateMetadataJSON()
   package=${ZOPEN_NAME}
   name=$(getProjectName "$package")
 
-  # Determine version
-  if [ -n "${versionString}" ]; then
-    version="${versionString}"
-  else
-    # Try to extract version from package name (handles optional v/V prefix)
-    version=$(extractVersionFromPackage "$package")
-    if [ -z "$version" ]; then
-      # Fallback to the last segment of the package name
-      version=$(normalizeVersion "$(echo "${package}" | sed 's/.*-//')")
-    fi
-  fi
+  # Determine version (guaranteed to be set and validated by install())
+  version="${versionString}"
 
   total_size=$(getPathSizeInBytes "${ZOPEN_INSTALL_DIR}")
 
@@ -2487,26 +2478,7 @@ install()
     else
       versionString=$(zopen_get_version)
       versionString=$(normalizeVersion "$versionString")
-      echo ${versionString} | awk -F. '{
-        if (NF < 1 || NF > 4) {
-          exit 1
-        }
-        if ($1 ~ /[^0-9]/) {
-          exit 1
-        }
-        if ($2 ~ /[^0-9]/) {
-          exit 1
-        }
-        if (NF >= 3 && $3 ~ /[^0-9A-Za-z-]+/) {
-          exit 1
-        }
-        if (NF == 4 && $4 !~ /[0-9A-Za-z-]+/) {
-          exit 1
-        }
-        exit 0
-      }'
-
-      if [ $? -ne 0 ]; then
+      if ! isValidVersion "${versionString}"; then
         printError "The version string \"${versionString}\" uses an invalid version format"
       fi
       asciiecho "${versionString}" "${ZOPEN_INSTALL_DIR}/.version"

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2151,14 +2151,14 @@ getProjectName()
     return 0
   fi
 
-  # Intelligent fallback: try to extract version and derive name
-  version=$(echo "$package" | sed -E 's/.*-([0-9].*)$/\1/')
+  # Intelligent fallback: try to extract version (handling optional 'v' prefix) and derive name
+  version=$(echo "$package" | sed -E 's/.*-([vV]?[0-9].*)$/\1/')
   if [ "$version" != "$package" ] && [ -n "$version" ]; then
     # Version was successfully extracted, remove it to get name
     echo "${package%-${version}}"
   else
-    # No version pattern found, fall back to old cut method
-    echo "$package" | cut -d "-" -f 1
+    # No version pattern found, return the full package name
+    echo "$package"
   fi
 }
 
@@ -2172,11 +2172,15 @@ generateMetadataJSON()
   if [ -n "${versionString}" ]; then
     version="${versionString}"
   else
-    # Try to extract version from package name (rightmost segment starting with digit)
-    version=$(echo "$package" | sed -E 's/.*-([0-9].*)$/\1/')
-    # If sed didn't find a pattern (returns whole string), fall back to old method
-    if [ "$version" = "$package" ]; then
-      version=$(echo ${package} | cut -d "-" -f 2)
+    # Try to extract version from package name (rightmost segment starting with digit or v/V prefix)
+    version=$(echo "$package" | sed -E 's/.*-([vV]?[0-9].*)$/\1/')
+    if [ "$version" != "$package" ] && [ -n "$version" ]; then
+      # Strip optional v/V prefix for consistency with numeric versioning
+      version="${version#[vV]}"
+    else
+      # Fallback to the last segment of the package name
+      version=$(echo "${package}" | sed 's/.*-//')
+      version="${version#[vV]}"
     fi
   fi
 
@@ -2460,6 +2464,7 @@ install()
       printError "A zopen_get_version() function must be defined in the buildenv to extract the version contents"
     else
       versionString=$(zopen_get_version)
+      versionString="${versionString#[vV]}"
       echo ${versionString} | awk -F. '{
         if (NF < 1 || NF > 4) {
           exit 1
@@ -2516,11 +2521,9 @@ fi
 cd \$curdir  >/dev/null 2>&1
 EOF
   printInfo "- Sourcing environment to run any setup"
-  original_dir=$(pwd)
-  cd "${ZOPEN_INSTALL_DIR}" && ./setup.sh
+  (cd "${ZOPEN_INSTALL_DIR}" && ./setup.sh)
   printVerbose "Marking this version as installed"
   touch "${ZOPEN_INSTALL_DIR}/.active"
-  cd "${original_dir}"
 }
 
 create_pax()

--- a/bin/zopen-generate
+++ b/bin/zopen-generate
@@ -649,7 +649,7 @@ get_version_impl='echo "1.0.0" # Modify to echo the version of your tool/library
 if [ -n "${stablePath}" ]; then
     version_block="# bump: $name-version /${version_var_name}=\"(.*)\"/ ${stablePath}|semver:*\n"
     if [ -n "$latest_tag" ]; then
-        plain_version=$(echo "${latest_tag}" | sed 's/^v//')
+        plain_version=$(normalizeVersion "${latest_tag}")
         version_block="${version_block}${version_var_name}=\"${plain_version}\""
         tag_export_for_insert="\nexport ZOPEN_STABLE_TAG=\"${latest_tag}\""
         get_version_impl="echo \"\$${version_var_name}\""

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -377,6 +377,7 @@ handlePackageInstall()
   downloadFile=$(basename "${downloadURL}")
   metadataFile="${downloadFile}.json" # use the same basename as the pax + .json to avoid collision
   downloadFileVer=$(echo "${downloadFile}" | sed -E 's/.*-(.*)\.zos\.pax\.Z/\1/')
+  downloadFileVer=$(normalizeVersion "$downloadFileVer")
   printVerbose "Downloading port from URL: ${downloadURL} to file: ${downloadFile} (ver=${downloadFileVer})"
 
   if ${downloadOnly}; then

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -101,9 +101,10 @@ parse_filename() {
     
     # Try to extract name and version using sed since BASH_REMATCH is a bashism
     # Pattern 1: NAME-VERSION (e.g., package-1.0, curl-8.10.1.20241001_214340)
-    if echo "$basename" | grep -qE '^(.+)-([0-9].*)$'; then
-        PKG_NAME=$(echo "$basename" | sed -E 's/^(.+)-([0-9].*)$/\1/')
-        PKG_VERSION=$(echo "$basename" | sed -E 's/^(.+)-([0-9].*)$/\2/')
+    if echo "$basename" | grep -qE '^(.+)-([vV]?[0-9].*)$'; then
+        PKG_NAME=$(echo "$basename" | sed -E 's/^(.+)-([vV]?[0-9].*)$/\1/')
+        PKG_VERSION=$(echo "$basename" | sed -E 's/^(.+)-([vV]?[0-9].*)$/\2/')
+        PKG_VERSION=$(normalizeVersion "$PKG_VERSION")
     # Pattern 2: NAMEVERSION.suffix (e.g., HAMN110.runnable)
     elif echo "$basename" | grep -qE '^([A-Za-z]+)([0-9]+)\.(.+)$'; then
         PKG_NAME=$(echo "$basename" | sed -E 's/^([A-Za-z]+)([0-9]+)\.(.+)$/\1/')
@@ -988,6 +989,9 @@ main() {
     if [ -z "$OUTPUT_FILE" ]; then
         OUTPUT_FILE="${PKG_NAME}.spec"
     fi
+    
+    # Normalize version: strip optional v/V prefix for RPM compatibility
+    PKG_VERSION=$(normalizeVersion "$PKG_VERSION")
     
     # Check for required tools
     if ! check_required_tools "$PAX_FILE"; then

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -104,7 +104,7 @@ parse_filename() {
     if echo "$basename" | grep -qE '^(.+)-([vV]?[0-9].*)$'; then
         PKG_NAME=$(echo "$basename" | sed -E 's/^(.+)-([vV]?[0-9].*)$/\1/')
         PKG_VERSION=$(echo "$basename" | sed -E 's/^(.+)-([vV]?[0-9].*)$/\2/')
-        PKG_VERSION=$(normalizeVersion "$PKG_VERSION")
+        PKG_VERSION=$(normalizeRpmVersion "$PKG_VERSION")
     # Pattern 2: NAMEVERSION.suffix (e.g., HAMN110.runnable)
     elif echo "$basename" | grep -qE '^([A-Za-z]+)([0-9]+)\.(.+)$'; then
         PKG_NAME=$(echo "$basename" | sed -E 's/^([A-Za-z]+)([0-9]+)\.(.+)$/\1/')
@@ -990,8 +990,8 @@ main() {
         OUTPUT_FILE="${PKG_NAME}.spec"
     fi
     
-    # Normalize version: strip optional v/V prefix for RPM compatibility
-    PKG_VERSION=$(normalizeVersion "$PKG_VERSION")
+    # Normalize version for RPM compatibility: strip optional v/V prefix and convert pre-release suffixes
+    PKG_VERSION=$(normalizeRpmVersion "$PKG_VERSION")
     
     # Check for required tools
     if ! check_required_tools "$PAX_FILE"; then

--- a/include/common.sh
+++ b/include/common.sh
@@ -1392,6 +1392,38 @@ validateVersion()
   return 0
 }
 
+#
+# Check if a version string follows a valid format (1-4 dot-separated parts, first two numeric)
+# Returns 0 if valid, 1 if invalid
+#
+isValidVersion()
+{
+  _ivv_version="$1"
+  if [ -z "${_ivv_version}" ]; then
+    return 1
+  fi
+  echo "${_ivv_version}" | awk -F. '{
+    if (NF < 1 || NF > 4) {
+      exit 1
+    }
+    if ($1 ~ /[^0-9]/) {
+      exit 1
+    }
+    if ($2 ~ /[^0-9]/) {
+      exit 1
+    }
+    if (NF >= 3 && $3 ~ /[^0-9A-Za-z-]+/) {
+      exit 1
+    }
+    if (NF == 4 && $4 !~ /[0-9A-Za-z-]+/) {
+      exit 1
+    }
+    exit 0
+  }'
+  return $?
+}
+
+
 deleteDuplicateEntries()
 {
   value=$1

--- a/include/common.sh
+++ b/include/common.sh
@@ -1264,21 +1264,104 @@ normalizeVersion()
   echo "${1#[vV]}"
 }
 
+#
+# Normalize version for RPM: strip v/V prefix and convert pre-releases to use ~
+# "1.8.2rc1" → "1.8.2~rc1", "1.8.2-rc1" → "1.8.2~rc1", "1.8.2.rc1" → "1.8.2~rc1"
+#
+normalizeRpmVersion()
+{
+  _nrv_version=$(normalizeVersion "$1")
+  echo "$_nrv_version" | /bin/sed -E 's/^([0-9]+(\.[0-9]+)*)[-.]?([a-zA-Z].*)$/\1~\3/'
+}
+
+
 compareVersions()
 {
-  v1="$1"
-  v2="$2"
-  awk -v v1="${v1}" -v v2="${v2}" '
-  function vercmp(v1, v2) {
-    n1 = split(v1, v1_array, ".")
-    n2 = split(v2, v2_array, ".")
+  _cv_v1=$(normalizeVersion "$1")
+  _cv_v2=$(normalizeVersion "$2")
+  awk -v v1="${_cv_v1}" -v v2="${_cv_v2}" '
+  # Helper to compare prerelease suffixes (e.g., "rc2" vs "rc12") by tokenizing
+  # them into alternating numeric and non-numeric chunks.
+  function cmp_prerelease(p1, p2) {
+    while (p1 != "" || p2 != "") {
+      if (p1 == "") return -1 # p1 has fewer tokens (is older)
+      if (p2 == "") return 1  # p2 has fewer tokens (is older)
 
-    for (i = 1; i <= n1 || i <= n2; i++) {
-      if (v1_array[i] != v2_array[i]) {
-        return (v1_array[i] < v2_array[i] ? -1 : 1)
+      # Extract next token from p1
+      if (match(p1, /^[0-9]+/)) {
+        tok1 = substr(p1, RSTART, RLENGTH)
+        is_num1 = 1
+        p1 = substr(p1, RSTART + RLENGTH)
+      } else {
+        match(p1, /^[^0-9]+/)
+        tok1 = substr(p1, RSTART, RLENGTH)
+        is_num1 = 0
+        p1 = substr(p1, RSTART + RLENGTH)
+      }
+
+      # Extract next token from p2
+      if (match(p2, /^[0-9]+/)) {
+        tok2 = substr(p2, RSTART, RLENGTH)
+        is_num2 = 1
+        p2 = substr(p2, RSTART + RLENGTH)
+      } else {
+        match(p2, /^[^0-9]+/)
+        tok2 = substr(p2, RSTART, RLENGTH)
+        is_num2 = 0
+        p2 = substr(p2, RSTART + RLENGTH)
+      }
+
+      # Compare the tokens
+      if (is_num1 && is_num2) {
+        val1 = tok1 + 0
+        val2 = tok2 + 0
+        if (val1 != val2) {
+          return (val1 < val2 ? -1 : 1)
+        }
+      } else {
+        if (tok1 != tok2) {
+          return (tok1 < tok2 ? -1 : 1)
+        }
       }
     }
     return 0
+  }
+
+  function vercmp(v1, v2) {
+    # 1. Separate release version from pre-release suffix
+    # Release part matches the leading numeric/dot portion: e.g., "1.2.3"
+    rel1 = ""; pre1 = ""
+    if (match(v1, /^[0-9]+(\.[0-9]+)*/)) {
+      rel1 = substr(v1, RSTART, RLENGTH)
+      pre1 = substr(v1, RSTART + RLENGTH)
+      sub(/^[-.]/, "", pre1) # strip leading - or .
+    }
+    
+    rel2 = ""; pre2 = ""
+    if (match(v2, /^[0-9]+(\.[0-9]+)*/)) {
+      rel2 = substr(v2, RSTART, RLENGTH)
+      pre2 = substr(v2, RSTART + RLENGTH)
+      sub(/^[-.]/, "", pre2) # strip leading - or .
+    }
+
+    # 2. Compare release versions component by component
+    n1 = split(rel1, r1_array, ".")
+    n2 = split(rel2, r2_array, ".")
+    max_len = (n1 > n2 ? n1 : n2)
+    for (i = 1; i <= max_len; i++) {
+      val1 = (i <= n1 ? r1_array[i] + 0 : 0)
+      val2 = (i <= n2 ? r2_array[i] + 0 : 0)
+      if (val1 != val2) {
+        return (val1 < val2 ? -1 : 1)
+      }
+    }
+
+    # 3. Compare pre-releases if release versions are identical
+    if (pre1 == "" && pre2 == "") return 0
+    if (pre1 != "" && pre2 == "") return -1 # pre-release is older than release
+    if (pre1 == "" && pre2 != "") return 1  # release is newer than pre-release
+
+    return cmp_prerelease(pre1, pre2)
   }
 
   BEGIN {

--- a/include/common.sh
+++ b/include/common.sh
@@ -1255,6 +1255,15 @@ normalizeDeps()
   ' | tr '\n' ' '
 }
 
+#
+# Strip v/V prefix from a version string for consistent numeric versioning
+# "v1.2.3" → "1.2.3", "V1.2.3" → "1.2.3", "1.2.3" → "1.2.3", "" → ""
+#
+normalizeVersion()
+{
+  echo "${1#[vV]}"
+}
+
 compareVersions()
 {
   v1="$1"


### PR DESCRIPTION
Updated version extraction to handle optional 'v' prefix.

<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [x] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
- Fix project_name extraction logic
- execute setup.sh in a subshell

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
