### PR TITLE
Fix: Prevent ANSI color codes under OMVS and display version in zopen help

### DIFF
--- a/bin/zopen
+++ b/bin/zopen
@@ -22,8 +22,12 @@ setupMyself
 
 
 printHelp(){
+  zopen_version="unknown"
+  if [ -f "${INCDIR}/zopen_version" ]; then
+    zopen_version=$(cat "${INCDIR}/zopen_version")
+  fi
 cat << HELPDOC
-${ME} is a utility for managing a zopen community environment.
+${ME} (${zopen_version}) is a utility for managing a zopen community environment.
 
 Usage: ${ME} [COMMAND] [OPTION] [PARAMETERS]...
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -464,7 +464,7 @@ defineANSI()
   CRSRSHOW="${ESC}[?25h"
 
   # Color-type codes, needs explicit terminal settings
-  if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
+  if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ "${ORIGINAL_TERM}" != "dumb" ] && [ "${ORIGINAL_TERM}" != "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
     esc="${ESC}"
     BLACK="${esc}[30m"
     RED="${esc}[31m"
@@ -593,6 +593,7 @@ defineEnvironment()
   export _TAG_REDIR_OUT=txt
   export GIT_UTF8_CCSID=819
   unset _ENCODE_FILE_NEW # rely on the default tool encoding behaviour
+  export ORIGINAL_TERM="${TERM}"
   export TERM=xterm # To avoid potential issues with "FSUM6202 Unknown terminal" if using an ncurses terminal database
 
   # Required for proper operation of xlclang


### PR DESCRIPTION
Fixes #1143 

### What type of PR is this?
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

### Category
- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

### Description
This PR addresses two UX/UI issues reported when using `zopen` in the native z/OS OMVS terminal:

1. **Strange Characters in OMVS:** 
   The OMVS native terminal (often initialized as `TERM=dumb` or `TERM=OMVS`) does not correctly support ANSI escape sequences, resulting in raw characters being printed (like `ESC[31m`) instead of actual colors. Previously, `include/common.sh` forcibly overwrote `TERM` with `xterm` to avoid ncurses compatibility errors *before* the terminal was checked for ANSI compatibility. 
   **Fix:** We now capture the original terminal value into `ORIGINAL_TERM` and check that it is not `dumb` and not `OMVS` before enabling ANSI outputs.

2. **Version Indicator in Help Title:** 
   When the user executes `zopen` with no arguments or with `--help`, there was no version displayed.
   **Fix:** Updated the `printHelp()` function in `bin/zopen` to dynamically fetch the version from `include/zopen_version` and display it alongside the tool name in the help header.

### Related Issues
- Closes #1143

### Verification
- Verified that `zopen --help` correctly displays the version.
- Verified that running `TERM=dumb zopen` or running directly under OMVS avoids emitting unsupported ANSI color codes.
