### PR TITLE
Fix: Quote -? in arg parsing to prevent globbing

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -245,7 +245,7 @@ while [ \$# -gt 0 ]; do
     --nooverride-zos-tools)  unset ZOPEN_TOOLSET_OVERRIDE;;
     --override-zos-tools-subset) shift;  export ZOPEN_TOOLSET_OVERRIDE=1; overrideFile="\$1";;
     --quiet) displayText=false;;
-    -?|--help) displayHelp; return 0;;
+    '-?'|--help) displayHelp; return 0;;
   esac
   shift
 done


### PR DESCRIPTION
Fixes #1166

### What type of PR is this?
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

### Category
- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

### Description
This PR addresses an issue where `zopen-config` hijacks unrelated short-flag arguments when sourced in bash. 

**The Bug:**
In the configuration generation script `include/common.sh`, the case statement checking for the help flag was ` -?|--help)`. Because the question mark was not escaped or quoted, bash treats `-?` as a single-character glob pattern matching a hyphen followed by any single character (like `-a`, `-b`, `-x`). If a user sourced `zopen-config` from a script that had an active short flag, it would intercept it, print the `zopen` help menu, and abruptly exit.

**The Fix:**
Quoted the argument `'-?'|--help)` to ensure it is evaluated as a literal string.

### Related Issues
- Closes #1166

### Verification
- Verified that the generated `zopen-config` correctly evaluates the arguments without wildcard globbing matching any arbitrary `-x` flag.
