### PR TITLE
Fix: Protect script arguments and prevent namespace pollution in zopen-config

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -237,18 +237,27 @@ knv=false
 exportknv=""
 displayText=true
 unset overrideFile
-while [ \$# -gt 0 ]; do
-  case "\$1" in
-    --eknv) exportknv="export "; knv=true;;
-    --knv) knv=true;;
-    --override-zos-tools)  export ZOPEN_TOOLSET_OVERRIDE=1;;
-    --nooverride-zos-tools)  unset ZOPEN_TOOLSET_OVERRIDE;;
-    --override-zos-tools-subset) shift;  export ZOPEN_TOOLSET_OVERRIDE=1; overrideFile="\$1";;
-    --quiet) displayText=false;;
-    -?|--help) displayHelp; return 0;;
-  esac
-  shift
-done
+_zopen_config_parse_args() {
+  while [ \$# -gt 0 ]; do
+    case "\$1" in
+      --eknv) exportknv="export "; knv=true;;
+      --knv) knv=true;;
+      --override-zos-tools)  export ZOPEN_TOOLSET_OVERRIDE=1;;
+      --nooverride-zos-tools)  unset ZOPEN_TOOLSET_OVERRIDE;;
+      --override-zos-tools-subset) shift;  export ZOPEN_TOOLSET_OVERRIDE=1; overrideFile="\$1";;
+      --quiet) displayText=false;;
+      '-?'|--help) displayHelp; return 1;;
+    esac
+    shift
+  done
+  return 0
+}
+_zopen_config_parse_args "\$@"
+_zopen_config_parse_args_rc=\$?
+if [ \$_zopen_config_parse_args_rc -ne 0 ]; then
+  unset -f displayHelp sanitizeEnvVar deleteDuplicateEntries _zopen_config_parse_args 2>/dev/null
+  return 0 2>/dev/null || exit 0
+fi
 if \${knv}; then
   /bin/env | /bin/sort > /tmp/zopen-config-env-orig.\$\$
 fi
@@ -390,7 +399,7 @@ if \${knv}; then
   rm /tmp/zopen-config-env-orig.\$\$ /tmp/zopen-config-env-modded.\$\$ 2>/dev/null
 fi
 
-
+unset -f displayHelp sanitizeEnvVar deleteDuplicateEntries _zopen_config_parse_args 2>/dev/null
 EOF
 
 }


### PR DESCRIPTION
Fixes #1119
Fixes #1121

### What type of PR is this?
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

### Category
- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

### Description
This PR addresses two critical namespace and argument pollution issues when users `source` the `zopen-config` file.

**The Bugs:**
1. **Argument Consumption (#1119):** `zopen-config` directly used `shift` to parse arguments passed to it. When sourced inside a script, this actually shifted the arguments (`$1`, `$2`, etc.) of the calling script itself, permanently destroying the calling script's positional parameters.
2. **Namespace Pollution (#1121):** `zopen-config` defines helper functions like `displayHelp`, `sanitizeEnvVar`, and `deleteDuplicateEntries` to perform setup. Because the script is sourced, these functions remained globally available, polluting the user's interactive shell or script namespace.

**The Fix:**
- Wrapped the argument parsing `while` loop inside a new local function `_zopen_config_parse_args`. Running `shift` inside a function operates safely on the function's own parameters without touching the caller's `$@` array.
- Appended `unset -f displayHelp sanitizeEnvVar deleteDuplicateEntries _zopen_config_parse_args 2>/dev/null` to the very end of `zopen-config` (as well as prior to early-returning when `--help` is invoked) to guarantee a clean environment.

### Related Issues
- Closes #1119
- Closes #1121

### Verification
- Verified that sourcing `zopen-config` from a script containing `"$@"` arguments leaves them completely intact.
- Verified that running `type displayHelp` after sourcing the config correctly shows it is undefined.
