### PR TITLE
RPM packaging improvements

### DIFF
--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -220,8 +220,8 @@ list_pax_contents() {
 # Function to generate install commands based on analyzed contents
 # Distributes files into FHS-like directories under /opt/pkg/
 generate_install_commands() {
-pax_file="$1"
-    
+    pax_file="$1"
+
     cat << 'EOF'
 # Install files into FHS-like filesystem hierarchy under /opt/pkg/
 
@@ -234,25 +234,27 @@ if [ -d usr ]; then
     # directory such as lib/plugin/bin/ when the real root is one level up.
     ROOT_DIR=""
     # Collect all candidate parent dirs that have at least one FHS child,
-    # sort by depth (fewest slashes first), and take the first one.
+    # sort by depth (fewest slashes first) then alphabetically for determinism.
     ROOT_DIR=$(find . -type d \( \
             -name bin -o -name lib -o -name libexec -o \
             -name include -o -name etc -o -name share -o \
             -name altbin -o -name pyz -o -name bash -o -name go \) -print | \
         sed 's|/[^/]*$||' | \
         sed 's|^\./||' | \
+        sort -u | \
         awk -F/ '{ print NF" "$0 }' | \
-        sort -n | \
+        sort -n -k2 | \
         awk 'NR==1{ print $2 }')
 
     if [ -z "$ROOT_DIR" ] || [ "$ROOT_DIR" = "." ]; then
         # Fallback: walk down single-child directories until we find a
         # directory with more than one entry (the real content root).
+        # Use find instead of ls -1 so dotfiles are counted correctly.
         ROOT_DIR="."
-        while [ "$(ls -1 "$ROOT_DIR" 2>/dev/null | wc -l)" -eq 1 ]; do
-            SUB_DIR=$(ls -1 "$ROOT_DIR")
-            if [ -d "$ROOT_DIR/$SUB_DIR" ]; then
-                ROOT_DIR="$ROOT_DIR/$SUB_DIR"
+        while [ "$(find "$ROOT_DIR" -maxdepth 1 -mindepth 1 | wc -l)" -eq 1 ]; do
+            SUB_DIR=$(find "$ROOT_DIR" -maxdepth 1 -mindepth 1)
+            if [ -d "$SUB_DIR" ]; then
+                ROOT_DIR="$SUB_DIR"
             else
                 break
             fi
@@ -260,9 +262,9 @@ if [ -d usr ]; then
     fi
     echo "Detected package root: $ROOT_DIR"
     cd "$ROOT_DIR" || { echo "ERROR: could not cd into $ROOT_DIR" >&2; exit 1; }
-elif [ $(ls -1 | grep -v "^$" | wc -l) -eq 1 ] && [ -d * ]; then
+elif [ "$(find . -maxdepth 1 -mindepth 1 | wc -l)" -eq 1 ] && [ -d "$(find . -maxdepth 1 -mindepth 1)" ]; then
     # Standard single-directory layout (e.g., go/)
-    SUB_DIR=$(ls -1)
+    SUB_DIR=$(find . -maxdepth 1 -mindepth 1)
     echo "Standard single-directory layout detected: $SUB_DIR"
     cd "$SUB_DIR" || { echo "ERROR: could not cd into $SUB_DIR" >&2; exit 1; }
 else
@@ -347,10 +349,17 @@ _BR="%{buildroot}"
 _ALLFILES=$(mktemp)
 _CFGFILES=$(mktemp)
 _DOCFILES=$(mktemp)
+_EMPTYDIRS=$(mktemp)
 
 find "${_BR}" -type f -o -type l | sed "s|^${_BR}||" | sort > "$_ALLFILES"
 
-# Split into tagged buckets
+# Collect empty directories — these must be listed explicitly with %dir
+# otherwise RPM won't create them and packages relying on them will break.
+find "${_BR}" -type d -empty | sed "s|^${_BR}||" | sort > "$_EMPTYDIRS"
+
+# Split files into tagged buckets
+# Remove $_FILELIST.plain upfront in case a previous run left it behind.
+rm -f "$_FILELIST.plain"
 while IFS= read -r _f; do
     case "$_f" in
         %{_sysconfdir}/*) echo "%config(noreplace) $_f" >> "$_CFGFILES" ;;
@@ -359,14 +368,18 @@ while IFS= read -r _f; do
     esac
 done < "$_ALLFILES"
 
-# Assemble final filelist: defattr first, then plain, config, doc
+# Assemble final filelist: defattr first, then plain, config, doc, empty dirs
 echo '%defattr(-,root,root,-)' > "$_FILELIST"
 [ -f "$_FILELIST.plain" ] && cat "$_FILELIST.plain" >> "$_FILELIST"
 [ -f "$_CFGFILES" ]       && cat "$_CFGFILES"       >> "$_FILELIST"
 [ -f "$_DOCFILES" ]       && cat "$_DOCFILES"        >> "$_FILELIST"
+# Emit empty directories with %dir so RPM owns and creates them at install time
+while IFS= read -r _d; do
+    [ -n "$_d" ] && echo "%dir $_d" >> "$_FILELIST"
+done < "$_EMPTYDIRS"
 
 # Cleanup temp files
-rm -f "$_ALLFILES" "$_CFGFILES" "$_DOCFILES" "$_FILELIST.plain"
+rm -f "$_ALLFILES" "$_CFGFILES" "$_DOCFILES" "$_FILELIST.plain" "$_EMPTYDIRS"
 
 # Warn if nothing was installed
 if [ "$(grep -c . "$_FILELIST" 2>/dev/null)" -le 1 ]; then
@@ -383,7 +396,7 @@ generate_spec() {
 output_file="$1"
 source_file="$2"
 date=$(date "+%a %b %d %Y")
-    
+
     # Analyze the pax contents first (populate global DIR_STRUCTURE)
     analyze_pax_contents "$source_file"
     
@@ -467,7 +480,7 @@ rm -rf %{buildroot}
 
 $(generate_install_commands "$source_file")
 
-%files -f rpm_filelist.txt
+%files -f %{_builddir}/%{name}-%{version}/rpm_filelist.txt
 
 %changelog
 * ${date} ${PACKAGER_NAME} <${PACKAGER_EMAIL}> - ${PKG_VERSION}-${RELEASE}
@@ -881,7 +894,7 @@ buildroot="$3"
 source_name=$(basename "$pax_file")
     echo "Copying source file to $buildroot/SOURCES/$source_name"
     cp "$pax_file" "$buildroot/SOURCES/"
-    
+
     # Copy spec file to SPECS
     echo "Copying spec file to $buildroot/SPECS/"
     cp "$spec_file" "$buildroot/SPECS/"

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -156,7 +156,6 @@ analyze_pax_contents() {
     has_altbin=false
     has_libexec=false
     has_data=false
-    is_os_layout=false
     
     # Analyze each file
     while IFS= read -r line; do
@@ -168,7 +167,7 @@ analyze_pax_contents() {
         [ -z "$filename" ] && continue
         
         # Detect directory structure using shell globs.
-        # Patterns like */bin/* match at any depth (e.g. usr/lpp/IBM/bin/).
+        # Patterns like */bin/* match at any depth (e.g. deeply nested bin/ dirs).
         # This is intentional: we only need to know whether a category exists,
         # not where exactly — root detection is handled separately in generate_install_commands().
         case "$filename" in
@@ -194,8 +193,6 @@ analyze_pax_contents() {
                 has_libexec=true ;;
             data/* | */data/*)
                 has_data=true ;;
-            usr/lpp/* | */usr/lpp/*)
-                is_os_layout=true ;;
         esac
     done << EOF
 $pax_listing
@@ -226,45 +223,7 @@ generate_install_commands() {
 # Install files into FHS-like filesystem hierarchy under /opt/pkg/
 
 # Detect the source layout and find the content root
-if [ -d usr ]; then
-    echo "OS layout (usr/) detected, searching for actual package root..."
-    # Strategy: find the shallowest directory whose parent contains at least
-    # one *binary/library* FHS child (bin, lib, libexec, include, altbin).
-    # We intentionally exclude 'share', 'etc', and 'man' as anchors because
-    # these exist at the OS level (e.g. usr/share/) and would incorrectly
-    # select 'usr' instead of the real package root deeper in the tree
-    # (e.g. usr/lpp/foo/ which contains the actual bin/ and lib/).
-    ROOT_DIR=""
-    # Collect all candidate parent dirs that have at least one binary/library
-    # FHS child, sort by depth (fewest slashes first) then alphabetically.
-    ROOT_DIR=$(find . -type d \( \
-            -name bin -o -name lib -o -name libexec -o \
-            -name include -o -name altbin -o \
-            -name pyz -o -name bash -o -name go \) -print | \
-        sed 's|/[^/]*$||' | \
-        sed 's|^\./||' | \
-        sort -u | \
-        awk -F/ '{ print NF" "$0 }' | \
-        sort -n -k1,1 -k2 | \
-        awk 'NR==1{ sub(/^[0-9]+ /,""); print }')
-
-    if [ -z "$ROOT_DIR" ] || [ "$ROOT_DIR" = "." ]; then
-        # Fallback: walk down single-child directories until we find a
-        # directory with more than one entry (the real content root).
-        # Use find instead of ls -1 so dotfiles are counted correctly.
-        ROOT_DIR="."
-        while [ "$(find "$ROOT_DIR" -maxdepth 1 -mindepth 1 | wc -l)" -eq 1 ]; do
-            SUB_DIR=$(find "$ROOT_DIR" -maxdepth 1 -mindepth 1)
-            if [ -d "$SUB_DIR" ]; then
-                ROOT_DIR="$SUB_DIR"
-            else
-                break
-            fi
-        done
-    fi
-    echo "Detected package root: $ROOT_DIR"
-    cd "$ROOT_DIR" || { echo "ERROR: could not cd into $ROOT_DIR" >&2; exit 1; }
-elif [ "$(find . -maxdepth 1 -mindepth 1 | wc -l)" -eq 1 ] && [ -d "$(find . -maxdepth 1 -mindepth 1)" ]; then
+if [ "$(find . -maxdepth 1 -mindepth 1 | wc -l)" -eq 1 ] && [ -d "$(find . -maxdepth 1 -mindepth 1)" ]; then
     # Standard single-directory layout (e.g., go/)
     SUB_DIR=$(find . -maxdepth 1 -mindepth 1)
     echo "Standard single-directory layout detected: $SUB_DIR"

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -336,37 +336,38 @@ for docfile in README* LICENSE* COPYING* CHANGELOG* AUTHORS* INSTALL* NEWS*; do
     fi
 done
 
-# Generate RPM file list based on what was actually installed in buildroot.
-# Only list directories that exist and are non-empty to avoid RPM "File not found" errors.
+# Generate RPM file list by walking the actual buildroot tree.
+# We enumerate every file and directory installed under %{buildroot} so that
+# RPM owns exactly what was installed — no "Installed (but unpackaged)" errors
+# and no empty payload from listing a directory that rpmbuild cannot traverse.
 _FILELIST="%{_builddir}/%{name}-%{version}/rpm_filelist.txt"
 echo '%defattr(-,root,root,-)' > "$_FILELIST"
+_BR="%{buildroot}"
+_BR_LEN=$(echo "$_BR" | wc -c)   # includes trailing newline — used to strip prefix
 
-# Check each FHS directory in buildroot
-for _dir in "%{_bindir}" "%{_altbindir}" "%{_libdir}" "%{_libexecdir}" "%{_includedir}" "%{_libexecdir}/%{name}"; do
-    if [ -d "%{buildroot}${_dir}" ] && [ "$(ls -A "%{buildroot}${_dir}" 2>/dev/null)" ]; then
-        echo "${_dir}" >> "$_FILELIST"
-    fi
+# Walk every regular file and symlink under buildroot and emit its
+# package-relative path.  Directories are intentionally omitted: RPM
+# creates them automatically when it installs the files they contain,
+# which avoids ownership conflicts between packages that share a directory
+# (e.g. /opt/pkg/bin).  The sole exception is an empty top-level directory,
+# handled at the end.
+_HAVE_FILES=false
+find "$_BR" \( -type f -o -type l \) | sort | while IFS= read -r _abs; do
+    _rel="/${_abs#${_BR}/}"
+    # Tag config files
+    case "$_rel" in
+        %{_sysconfdir}/*) echo "%config(noreplace) $_rel" >> "$_FILELIST" ;;
+        %{_docdir}/*)     echo "%doc $_rel"              >> "$_FILELIST" ;;
+        %{_mandir}/*)     echo "%doc $_rel"              >> "$_FILELIST" ;;
+        *)                echo "$_rel"                   >> "$_FILELIST" ;;
+    esac
+    _HAVE_FILES=true
 done
 
-# Config files get %config tag
-if [ -d "%{buildroot}%{_sysconfdir}" ] && [ "$(ls -A "%{buildroot}%{_sysconfdir}" 2>/dev/null)" ]; then
-    echo "%config %{_sysconfdir}" >> "$_FILELIST"
-fi
-
-# share/ is parent of docdir, mandir, miscdir — list it if non-empty
-if [ -d "%{buildroot}%{_datadir}" ] && [ "$(ls -A "%{buildroot}%{_datadir}" 2>/dev/null)" ]; then
-    echo "%{_datadir}" >> "$_FILELIST"
-else
-    # Fall back to listing individual subdirs under share/
-    if [ -d "%{buildroot}%{_docdir}" ] && [ "$(ls -A "%{buildroot}%{_docdir}" 2>/dev/null)" ]; then
-        echo "%doc %{_docdir}" >> "$_FILELIST"
-    fi
-    if [ -d "%{buildroot}%{_pkgdatadir}" ] && [ "$(ls -A "%{buildroot}%{_pkgdatadir}" 2>/dev/null)" ]; then
-        echo "%{_pkgdatadir}" >> "$_FILELIST"
-    fi
-    if [ -d "%{buildroot}%{_miscdir}" ] && [ "$(ls -A "%{buildroot}%{_miscdir}" 2>/dev/null)" ]; then
-        echo "%{_miscdir}" >> "$_FILELIST"
-    fi
+# If nothing was installed at all, emit a warning so the build fails loudly
+# rather than producing a silent empty package.
+if [ ! -s "$_FILELIST" ] || [ "$(grep -c . "$_FILELIST")" -le 1 ]; then
+    echo "WARNING: No files were installed into %{buildroot}. RPM payload will be empty." >&2
 fi
 
 echo "Generated RPM file list:"

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -316,6 +316,7 @@ done
 for item in *; do
     case "$item" in
         bin|altbin|lib|libexec|include|etc|share|man|doc|docs|scripts|data) continue ;;
+        install_test.sh|metadata.json|setup.sh|test.status|README.md) continue ;;
     esac
     if [ -e "$item" ]; then
         echo "Installing misc item: $item -> %{_miscdir}"
@@ -326,6 +327,9 @@ done
 
 # Install root-level documentation (README, LICENSE, etc.)
 for docfile in README* LICENSE* COPYING* CHANGELOG* AUTHORS* INSTALL* NEWS*; do
+    case "$docfile" in
+        README.md) continue ;;
+    esac
     if [ -f "$docfile" ]; then
         mkdir -p %{buildroot}%{_docdir}
         pax -rw -p p "$docfile" %{buildroot}%{_docdir}/

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -264,7 +264,7 @@ elif [ $(ls -1 | grep -v "^$" | wc -l) -eq 1 ] && [ -d * ]; then
     # Standard single-directory layout (e.g., go/)
     SUB_DIR=$(ls -1)
     echo "Standard single-directory layout detected: $SUB_DIR"
-    cd "$SUB_DIR"
+    cd "$SUB_DIR" || { echo "ERROR: could not cd into $SUB_DIR" >&2; exit 1; }
 else
     # Flat or mixed layout — already in the right place
     echo "Flat or mixed layout detected"
@@ -409,7 +409,7 @@ Summary:        ${SUMMARY}
 %define _mandir %{_datadir}/man
 %define _libexecdir %{_prefix}/libexec
 %define _altbindir %{_prefix}/altbin
-%define _miscdir %{_prefix}/share/%{name}
+%define _miscdir %{_prefix}/share/%{name}/misc
 %define _pkgdatadir %{_datadir}/%{name}
 
 License:        ${LICENSE}

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -154,6 +154,9 @@ analyze_pax_contents() {
     has_doc=false
     has_man=false
     has_scripts=false
+    has_altbin=false
+    has_libexec=false
+    has_data=false
     is_os_layout=false
     
     # Analyze each file
@@ -185,6 +188,12 @@ analyze_pax_contents() {
                 has_man=true ;;
             scripts/* | */scripts/*)
                 has_scripts=true ;;
+            altbin/* | */altbin/*)
+                has_altbin=true ;;
+            libexec/* | */libexec/*)
+                has_libexec=true ;;
+            data/* | */data/*)
+                has_data=true ;;
             usr/lpp/* | */usr/lpp/*)
                 is_os_layout=true ;;
         esac
@@ -211,15 +220,14 @@ list_pax_contents() {
     esac
 }
 # Function to generate install commands based on analyzed contents
-# Function to generate install commands based on analyzed contents
-# Function to generate install commands based on analyzed contents
+# Distributes files into FHS-like directories under /opt/pkg/
 generate_install_commands() {
 pax_file="$1"
     
     cat << 'EOF'
-# Install files based on detected structure
+# Install files into FHS-like filesystem hierarchy under /opt/pkg/
 
-# Detect the source layout
+# Detect the source layout and find the content root
 if [ -d usr ]; then
     echo "OS layout (usr/) detected, searching for actual content root..."
     # Find the deepest directory that contains bin, lib, pyz, bash, or go
@@ -249,37 +257,116 @@ if [ -d usr ]; then
         done
     fi
     echo "Detected nested root: $ROOT_DIR"
-    mkdir -p %{buildroot}%{install_dir}
-    (cd "$ROOT_DIR" && pax -rw -p p . %{buildroot}%{install_dir}/)
+    cd "$ROOT_DIR"
 elif [ $(ls -1 | grep -v "^$" | wc -l) -eq 1 ] && [ -d * ]; then
     # Standard single-directory layout (e.g., go/)
     SUB_DIR=$(ls -1)
     echo "Standard single-directory layout detected: $SUB_DIR"
-    mkdir -p %{buildroot}%{install_dir}
-    (cd "$SUB_DIR" && pax -rw -p p . %{buildroot}%{install_dir}/)
+    cd "$SUB_DIR"
 else
-    # Flat or mixed layout
+    # Flat or mixed layout — already in the right place
     echo "Flat or mixed layout detected"
-    mkdir -p %{buildroot}%{install_dir}
-    (pax -rw -p p . %{buildroot}%{install_dir}/)
 fi
 
-# Install root-level documentation if it hasn't been copied already
-# (Matches files in the CURRENT directory, not ROOT_DIR)
-for doc in README* LICENSE* COPYING* CHANGELOG* AUTHORS* INSTALL* NEWS*; do
-    if [ -f "$doc" ]; then
-        mkdir -p %{buildroot}%{install_dir}/doc
-        pax -rw -p p "$doc" %{buildroot}%{install_dir}/doc/
+# Distribute known directories to their FHS-correct paths
+for dir in bin altbin lib libexec include etc share man doc docs scripts data; do
+    if [ -d "$dir" ]; then
+        case "$dir" in
+            bin)
+                dest="%{buildroot}%{_bindir}"
+                ;;
+            altbin)
+                dest="%{buildroot}%{_altbindir}"
+                ;;
+            lib)
+                dest="%{buildroot}%{_libdir}"
+                ;;
+            libexec)
+                dest="%{buildroot}%{_libexecdir}"
+                ;;
+            include)
+                dest="%{buildroot}%{_includedir}"
+                ;;
+            etc)
+                dest="%{buildroot}%{_sysconfdir}"
+                ;;
+            share)
+                dest="%{buildroot}%{_datadir}"
+                ;;
+            man)
+                dest="%{buildroot}%{_mandir}"
+                ;;
+            doc|docs)
+                dest="%{buildroot}%{_docdir}"
+                ;;
+            scripts)
+                dest="%{buildroot}%{_libexecdir}/%{name}"
+                ;;
+            data)
+                dest="%{buildroot}%{_pkgdatadir}"
+                ;;
+        esac
+        echo "Installing $dir/ -> $dest"
+        mkdir -p "$dest"
+        (cd "$dir" && pax -rw -p p . "$dest/")
     fi
 done
-EOF
-}
 
+# Install remaining files/directories that don't match known FHS dirs
+for item in *; do
+    case "$item" in
+        bin|altbin|lib|libexec|include|etc|share|man|doc|docs|scripts|data) continue ;;
+    esac
+    if [ -e "$item" ]; then
+        echo "Installing misc item: $item -> %{_miscdir}"
+        mkdir -p "%{buildroot}%{_miscdir}"
+        pax -rw -p p "$item" "%{buildroot}%{_miscdir}/"
+    fi
+done
 
-generate_files_list() {
-    cat << 'EOF'
-%defattr(-,root,root,-)
-%{install_dir}
+# Install root-level documentation (README, LICENSE, etc.)
+for docfile in README* LICENSE* COPYING* CHANGELOG* AUTHORS* INSTALL* NEWS*; do
+    if [ -f "$docfile" ]; then
+        mkdir -p %{buildroot}%{_docdir}
+        pax -rw -p p "$docfile" %{buildroot}%{_docdir}/
+    fi
+done
+
+# Generate RPM file list based on what was actually installed in buildroot.
+# Only list directories that exist and are non-empty to avoid RPM "File not found" errors.
+_FILELIST="%{_builddir}/%{name}-%{version}/rpm_filelist.txt"
+echo '%defattr(-,root,root,-)' > "$_FILELIST"
+
+# Check each FHS directory in buildroot
+for _dir in "%{_bindir}" "%{_altbindir}" "%{_libdir}" "%{_libexecdir}" "%{_includedir}" "%{_libexecdir}/%{name}"; do
+    if [ -d "%{buildroot}${_dir}" ] && [ "$(ls -A "%{buildroot}${_dir}" 2>/dev/null)" ]; then
+        echo "${_dir}" >> "$_FILELIST"
+    fi
+done
+
+# Config files get %config tag
+if [ -d "%{buildroot}%{_sysconfdir}" ] && [ "$(ls -A "%{buildroot}%{_sysconfdir}" 2>/dev/null)" ]; then
+    echo "%config %{_sysconfdir}" >> "$_FILELIST"
+fi
+
+# share/ is parent of docdir, mandir, miscdir — list it if non-empty
+if [ -d "%{buildroot}%{_datadir}" ] && [ "$(ls -A "%{buildroot}%{_datadir}" 2>/dev/null)" ]; then
+    echo "%{_datadir}" >> "$_FILELIST"
+else
+    # Fall back to listing individual subdirs under share/
+    if [ -d "%{buildroot}%{_docdir}" ] && [ "$(ls -A "%{buildroot}%{_docdir}" 2>/dev/null)" ]; then
+        echo "%doc %{_docdir}" >> "$_FILELIST"
+    fi
+    if [ -d "%{buildroot}%{_pkgdatadir}" ] && [ "$(ls -A "%{buildroot}%{_pkgdatadir}" 2>/dev/null)" ]; then
+        echo "%{_pkgdatadir}" >> "$_FILELIST"
+    fi
+    if [ -d "%{buildroot}%{_miscdir}" ] && [ "$(ls -A "%{buildroot}%{_miscdir}" 2>/dev/null)" ]; then
+        echo "%{_miscdir}" >> "$_FILELIST"
+    fi
+fi
+
+echo "Generated RPM file list:"
+cat "$_FILELIST"
 EOF
 }
 
@@ -304,7 +391,18 @@ Version:        ${PKG_VERSION}
 Release:        ${RELEASE}%{?dist}
 Summary:        ${SUMMARY}
 
-%define install_dir /opt/pkg/%{name}/%{version}
+%define _prefix /opt/pkg
+%define _bindir %{_prefix}/bin
+%define _libdir %{_prefix}/lib
+%define _includedir %{_prefix}/include
+%define _sysconfdir %{_prefix}/etc
+%define _datadir %{_prefix}/share
+%define _docdir %{_datadir}/doc/%{name}
+%define _mandir %{_datadir}/man
+%define _libexecdir %{_prefix}/libexec
+%define _altbindir %{_prefix}/altbin
+%define _miscdir %{_prefix}/share/%{name}
+%define _pkgdatadir %{_datadir}/%{name}
 
 License:        ${LICENSE}
 ${URL:+URL:            $URL}
@@ -359,13 +457,9 @@ EOF
 %install
 rm -rf %{buildroot}
 
-# Create base installation directories
-mkdir -p %{buildroot}%{install_dir}
-
 $(generate_install_commands "$source_file")
 
-%files
-$(generate_files_list)
+%files -f rpm_filelist.txt
 
 %changelog
 * ${date} ${PACKAGER_NAME} <${PACKAGER_EMAIL}> - ${PKG_VERSION}-${RELEASE}
@@ -377,6 +471,7 @@ EOF
     echo ""
     echo "Detected structure:"
     [ "$has_bin" = "true" ] && echo "  ✓ Binaries in bin/"
+    [ "$has_altbin" = "true" ] && echo "  ✓ Alt binaries in altbin/"
     [ "$has_lib" = "true" ] && echo "  ✓ Libraries in lib/"
     [ "$has_include" = "true" ] && echo "  ✓ Headers in include/"
     [ "$has_etc" = "true" ] && echo "  ✓ Configuration files in etc/"
@@ -384,6 +479,8 @@ EOF
     [ "$has_doc" = "true" ] && echo "  ✓ Documentation in doc/"
     [ "$has_man" = "true" ] && echo "  ✓ Man pages in man/"
     [ "$has_scripts" = "true" ] && echo "  ✓ Scripts in scripts/"
+    [ "$has_libexec" = "true" ] && echo "  ✓ Helper binaries in libexec/"
+    [ "$has_data" = "true" ] && echo "  ✓ Application data in data/"
     
     return 0
 }

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -340,13 +340,13 @@ EOF
         *.pax.Z)
             cat >> "$output_file" << EOF
 # Extract compressed pax archive
-pax -rzf %{_sourcedir}/$(basename "$source_file")
+pax -r -p p -zf %{_sourcedir}/$(basename "$source_file")
 EOF
             ;;
         *)
             cat >> "$output_file" << EOF
 # Extract pax archive
-pax -rf %{_sourcedir}/$(basename "$source_file")
+pax -r -p p -f %{_sourcedir}/$(basename "$source_file")
 EOF
             ;;
     esac

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -228,23 +228,25 @@ generate_install_commands() {
 # Detect the source layout and find the content root
 if [ -d usr ]; then
     echo "OS layout (usr/) detected, searching for actual package root..."
-    # Strategy: find the shallowest directory that contains at least one
-    # known FHS child (bin, lib, libexec, include, etc, share, altbin).
-    # Using the shallowest match avoids mistakenly descending into a nested
-    # directory such as lib/plugin/bin/ when the real root is one level up.
+    # Strategy: find the shallowest directory whose parent contains at least
+    # one *binary/library* FHS child (bin, lib, libexec, include, altbin).
+    # We intentionally exclude 'share', 'etc', and 'man' as anchors because
+    # these exist at the OS level (e.g. usr/share/) and would incorrectly
+    # select 'usr' instead of the real package root deeper in the tree
+    # (e.g. usr/lpp/foo/ which contains the actual bin/ and lib/).
     ROOT_DIR=""
-    # Collect all candidate parent dirs that have at least one FHS child,
-    # sort by depth (fewest slashes first) then alphabetically for determinism.
+    # Collect all candidate parent dirs that have at least one binary/library
+    # FHS child, sort by depth (fewest slashes first) then alphabetically.
     ROOT_DIR=$(find . -type d \( \
             -name bin -o -name lib -o -name libexec -o \
-            -name include -o -name etc -o -name share -o \
-            -name altbin -o -name pyz -o -name bash -o -name go \) -print | \
+            -name include -o -name altbin -o \
+            -name pyz -o -name bash -o -name go \) -print | \
         sed 's|/[^/]*$||' | \
         sed 's|^\./||' | \
         sort -u | \
         awk -F/ '{ print NF" "$0 }' | \
-        sort -n -k2 | \
-        awk 'NR==1{ print $2 }')
+        sort -n -k1,1 -k2 | \
+        awk 'NR==1{ sub(/^[0-9]+ /,""); print }')
 
     if [ -z "$ROOT_DIR" ] || [ "$ROOT_DIR" = "." ]; then
         # Fallback: walk down single-child directories until we find a
@@ -312,7 +314,7 @@ for dir in bin altbin lib libexec include etc share man doc docs scripts data; d
         esac
         echo "Installing $dir/ -> $dest"
         mkdir -p "$dest"
-        (cd "$dir" && pax -rw -p p . "$dest/")
+        (cd "$dir" && pax -rw -p p . "$dest/") || { echo "ERROR: failed to install $dir/ -> $dest" >&2; exit 1; }
     fi
 done
 
@@ -326,7 +328,7 @@ for item in *; do
     if [ -e "$item" ]; then
         echo "Installing misc item: $item -> %{_miscdir}"
         mkdir -p "%{buildroot}%{_miscdir}"
-        pax -rw -p p "$item" "%{buildroot}%{_miscdir}/"
+        pax -rw -p p "$item" "%{buildroot}%{_miscdir}/" || { echo "ERROR: failed to install misc item $item" >&2; exit 1; }
     fi
 done
 
@@ -334,7 +336,7 @@ done
 for docfile in README* LICENSE* COPYING* CHANGELOG* AUTHORS* INSTALL* NEWS*; do
     if [ -f "$docfile" ]; then
         mkdir -p %{buildroot}%{_docdir}
-        pax -rw -p p "$docfile" %{buildroot}%{_docdir}/
+        pax -rw -p p "$docfile" %{buildroot}%{_docdir}/ || { echo "ERROR: failed to install doc file $docfile" >&2; exit 1; }
     fi
 done
 
@@ -351,7 +353,7 @@ _CFGFILES=$(mktemp)
 _DOCFILES=$(mktemp)
 _EMPTYDIRS=$(mktemp)
 
-find "${_BR}" -type f -o -type l | sed "s|^${_BR}||" | sort > "$_ALLFILES"
+find "${_BR}" \( -type f -o -type l \) -print | sed "s|^${_BR}||" | sort > "$_ALLFILES"
 
 # Collect empty directories — these must be listed explicitly with %dir
 # otherwise RPM won't create them and packages relying on them will break.

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -222,16 +222,15 @@ generate_install_commands() {
     cat << 'EOF'
 # Install files into FHS-like filesystem hierarchy under /opt/pkg/
 
-# Detect the source layout and find the content root
-if [ "$(find . -maxdepth 1 -mindepth 1 | wc -l)" -eq 1 ] && [ -d "$(find . -maxdepth 1 -mindepth 1)" ]; then
-    # Standard single-directory layout (e.g., go/)
-    SUB_DIR=$(find . -maxdepth 1 -mindepth 1)
-    echo "Standard single-directory layout detected: $SUB_DIR"
-    cd "$SUB_DIR" || { echo "ERROR: could not cd into $SUB_DIR" >&2; exit 1; }
-else
-    # Flat or mixed layout — already in the right place
-    echo "Flat or mixed layout detected"
+# zopen tool archives always extract to a single top-level directory
+# (e.g. curl-8.10.1/) containing bin/, lib/, etc. cd into it.
+SUB_DIR=$(find . -maxdepth 1 -mindepth 1 -type d | head -1)
+if [ -z "$SUB_DIR" ]; then
+    echo "ERROR: could not find top-level directory in extracted archive" >&2
+    exit 1
 fi
+echo "Entering package root: $SUB_DIR"
+cd "$SUB_DIR" || { echo "ERROR: could not cd into $SUB_DIR" >&2; exit 1; }
 
 # Distribute known directories to their FHS-correct paths
 for dir in bin altbin lib libexec include etc share man doc docs scripts data; do
@@ -324,8 +323,8 @@ rm -f "$_FILELIST.plain"
 while IFS= read -r _f; do
     case "$_f" in
         %{_sysconfdir}/*) echo "%config(noreplace) $_f" >> "$_CFGFILES" ;;
-        %{_docdir}/*|%{_mandir}/*) echo "%doc $_f"     >> "$_DOCFILES" ;;
-        *) echo "$_f" >> "$_FILELIST.plain" ;;
+        %{_docdir}/*)     echo "%doc $_f"              >> "$_DOCFILES" ;;
+        *)                echo "$_f"                   >> "$_FILELIST.plain" ;;
     esac
 done < "$_ALLFILES"
 
@@ -342,9 +341,11 @@ done < "$_EMPTYDIRS"
 # Cleanup temp files
 rm -f "$_ALLFILES" "$_CFGFILES" "$_DOCFILES" "$_FILELIST.plain" "$_EMPTYDIRS"
 
-# Warn if nothing was installed
+# Fail the build if nothing was installed — an empty RPM is always a bug.
+# A warning here would be silently ignored and produce a broken package.
 if [ "$(grep -c . "$_FILELIST" 2>/dev/null)" -le 1 ]; then
-    echo "WARNING: No files were installed into %{buildroot}. RPM payload will be empty." >&2
+    echo "ERROR: No files were installed into %{buildroot}. Refusing to build an empty RPM." >&2
+    exit 1
 fi
 
 echo "Generated RPM file list:"

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -125,8 +125,7 @@ parse_filename() {
 # Function to analyze pax contents and categorize files
 analyze_pax_contents() {
     pax_file="$1"
-    temp_dir=$(mktempdir "pax2rpm")
-    
+
     printInfo "# Analyzing pax file structure..."
     
     # Extract pax listing (limit to first 5000 entries for performance/accuracy balance)
@@ -168,9 +167,10 @@ analyze_pax_contents() {
         filename=$(echo "$line" | awk '{print $NF}')
         [ -z "$filename" ] && continue
         
-        # Detect directory structure (handles top-level dir if present)
-        # Matches: bin/, ./bin/, package-ver/bin/, ./package-ver/bin/
-        # Does NOT match: usr/lpp/IBM/bin/ (too deep)
+        # Detect directory structure using shell globs.
+        # Patterns like */bin/* match at any depth (e.g. usr/lpp/IBM/bin/).
+        # This is intentional: we only need to know whether a category exists,
+        # not where exactly — root detection is handled separately in generate_install_commands().
         case "$filename" in
             bin/* | */bin/*)
                 has_bin=true ;;
@@ -200,8 +200,6 @@ analyze_pax_contents() {
     done << EOF
 $pax_listing
 EOF
-    
-    rm -rf "$temp_dir"
 }
 
 # Function to list contents of pax file
@@ -229,25 +227,29 @@ pax_file="$1"
 
 # Detect the source layout and find the content root
 if [ -d usr ]; then
-    echo "OS layout (usr/) detected, searching for actual content root..."
-    # Find the deepest directory that contains bin, lib, pyz, bash, or go
-    # We sort by the number of slashes to find the deepest one
-    FOUND_PATH=$(find . -type d \( -name bin -o -name lib -o -name pyz -o -name bash -o -name go \) -print | awk -F/ '{print NF, $0}' | sort -rn | head -n 1 | cut -d' ' -f2-)
-    
-    if [ -n "$FOUND_PATH" ]; then
-        FOUND_PATH=${FOUND_PATH#./}
-        case "$FOUND_PATH" in
-            */pyz)
-                ROOT_DIR="$FOUND_PATH"
-                ;;
-            *)
-                ROOT_DIR=$(echo "$FOUND_PATH" | sed 's/\/\(bin\|lib\|bash\|go\)$//')
-                ;;
-        esac
-    else
-        # Fallback for OS layout: find first dir with more than one entry
+    echo "OS layout (usr/) detected, searching for actual package root..."
+    # Strategy: find the shallowest directory that contains at least one
+    # known FHS child (bin, lib, libexec, include, etc, share, altbin).
+    # Using the shallowest match avoids mistakenly descending into a nested
+    # directory such as lib/plugin/bin/ when the real root is one level up.
+    ROOT_DIR=""
+    # Collect all candidate parent dirs that have at least one FHS child,
+    # sort by depth (fewest slashes first), and take the first one.
+    ROOT_DIR=$(find . -type d \( \
+            -name bin -o -name lib -o -name libexec -o \
+            -name include -o -name etc -o -name share -o \
+            -name altbin -o -name pyz -o -name bash -o -name go \) -print | \
+        sed 's|/[^/]*$||' | \
+        sed 's|^\./||' | \
+        awk -F/ '{ print NF" "$0 }' | \
+        sort -n | \
+        awk 'NR==1{ print $2 }')
+
+    if [ -z "$ROOT_DIR" ] || [ "$ROOT_DIR" = "." ]; then
+        # Fallback: walk down single-child directories until we find a
+        # directory with more than one entry (the real content root).
         ROOT_DIR="."
-        while [ $(ls -1 "$ROOT_DIR" 2>/dev/null | wc -l) -eq 1 ]; do
+        while [ "$(ls -1 "$ROOT_DIR" 2>/dev/null | wc -l)" -eq 1 ]; do
             SUB_DIR=$(ls -1 "$ROOT_DIR")
             if [ -d "$ROOT_DIR/$SUB_DIR" ]; then
                 ROOT_DIR="$ROOT_DIR/$SUB_DIR"
@@ -256,8 +258,8 @@ if [ -d usr ]; then
             fi
         done
     fi
-    echo "Detected nested root: $ROOT_DIR"
-    cd "$ROOT_DIR"
+    echo "Detected package root: $ROOT_DIR"
+    cd "$ROOT_DIR" || { echo "ERROR: could not cd into $ROOT_DIR" >&2; exit 1; }
 elif [ $(ls -1 | grep -v "^$" | wc -l) -eq 1 ] && [ -d * ]; then
     # Standard single-directory layout (e.g., go/)
     SUB_DIR=$(ls -1)
@@ -316,7 +318,8 @@ done
 for item in *; do
     case "$item" in
         bin|altbin|lib|libexec|include|etc|share|man|doc|docs|scripts|data) continue ;;
-        install_test.sh|metadata.json|setup.sh|test.status|README.md) continue ;;
+        install_test.sh|metadata.json|setup.sh|test.status) continue ;;
+        README*|LICENSE*|COPYING*|CHANGELOG*|AUTHORS*|INSTALL*|NEWS*) continue ;;
     esac
     if [ -e "$item" ]; then
         echo "Installing misc item: $item -> %{_miscdir}"
@@ -327,46 +330,46 @@ done
 
 # Install root-level documentation (README, LICENSE, etc.)
 for docfile in README* LICENSE* COPYING* CHANGELOG* AUTHORS* INSTALL* NEWS*; do
-    case "$docfile" in
-        README.md) continue ;;
-    esac
     if [ -f "$docfile" ]; then
         mkdir -p %{buildroot}%{_docdir}
         pax -rw -p p "$docfile" %{buildroot}%{_docdir}/
     fi
 done
 
-# Generate RPM file list by walking the actual buildroot tree.
-# We enumerate every file and directory installed under %{buildroot} so that
-# RPM owns exactly what was installed — no "Installed (but unpackaged)" errors
-# and no empty payload from listing a directory that rpmbuild cannot traverse.
+# Generate RPM file list — standard Fedora/RHEL approach:
+# Use find to enumerate every file installed under %{buildroot}, then
+# strip the buildroot prefix with sed to get package-relative paths.
+# Config and doc files are tagged separately via post-processing.
 _FILELIST="%{_builddir}/%{name}-%{version}/rpm_filelist.txt"
-echo '%defattr(-,root,root,-)' > "$_FILELIST"
 _BR="%{buildroot}"
-_BR_LEN=$(echo "$_BR" | wc -c)   # includes trailing newline — used to strip prefix
 
-# Walk every regular file and symlink under buildroot and emit its
-# package-relative path.  Directories are intentionally omitted: RPM
-# creates them automatically when it installs the files they contain,
-# which avoids ownership conflicts between packages that share a directory
-# (e.g. /opt/pkg/bin).  The sole exception is an empty top-level directory,
-# handled at the end.
-_HAVE_FILES=false
-find "$_BR" \( -type f -o -type l \) | sort | while IFS= read -r _abs; do
-    _rel="/${_abs#${_BR}/}"
-    # Tag config files
-    case "$_rel" in
-        %{_sysconfdir}/*) echo "%config(noreplace) $_rel" >> "$_FILELIST" ;;
-        %{_docdir}/*)     echo "%doc $_rel"              >> "$_FILELIST" ;;
-        %{_mandir}/*)     echo "%doc $_rel"              >> "$_FILELIST" ;;
-        *)                echo "$_rel"                   >> "$_FILELIST" ;;
+# Separate config and doc files so they get the right RPM tags
+_ALLFILES=$(mktemp)
+_CFGFILES=$(mktemp)
+_DOCFILES=$(mktemp)
+
+find "${_BR}" -type f -o -type l | sed "s|^${_BR}||" | sort > "$_ALLFILES"
+
+# Split into tagged buckets
+while IFS= read -r _f; do
+    case "$_f" in
+        %{_sysconfdir}/*) echo "%config(noreplace) $_f" >> "$_CFGFILES" ;;
+        %{_docdir}/*|%{_mandir}/*) echo "%doc $_f"     >> "$_DOCFILES" ;;
+        *) echo "$_f" >> "$_FILELIST.plain" ;;
     esac
-    _HAVE_FILES=true
-done
+done < "$_ALLFILES"
 
-# If nothing was installed at all, emit a warning so the build fails loudly
-# rather than producing a silent empty package.
-if [ ! -s "$_FILELIST" ] || [ "$(grep -c . "$_FILELIST")" -le 1 ]; then
+# Assemble final filelist: defattr first, then plain, config, doc
+echo '%defattr(-,root,root,-)' > "$_FILELIST"
+[ -f "$_FILELIST.plain" ] && cat "$_FILELIST.plain" >> "$_FILELIST"
+[ -f "$_CFGFILES" ]       && cat "$_CFGFILES"       >> "$_FILELIST"
+[ -f "$_DOCFILES" ]       && cat "$_DOCFILES"        >> "$_FILELIST"
+
+# Cleanup temp files
+rm -f "$_ALLFILES" "$_CFGFILES" "$_DOCFILES" "$_FILELIST.plain"
+
+# Warn if nothing was installed
+if [ "$(grep -c . "$_FILELIST" 2>/dev/null)" -le 1 ]; then
     echo "WARNING: No files were installed into %{buildroot}. RPM payload will be empty." >&2
 fi
 

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -156,7 +156,7 @@ analyze_pax_contents() {
     has_altbin=false
     has_libexec=false
     has_data=false
-    
+    is_os_layout=false
     # Analyze each file
     while IFS= read -r line; do
         # Skip empty lines and headers
@@ -167,7 +167,7 @@ analyze_pax_contents() {
         [ -z "$filename" ] && continue
         
         # Detect directory structure using shell globs.
-        # Patterns like */bin/* match at any depth (e.g. deeply nested bin/ dirs).
+        # Patterns like */bin/* match at any depth (e.g. usr/lpp/IBM/bin/).
         # This is intentional: we only need to know whether a category exists,
         # not where exactly — root detection is handled separately in generate_install_commands().
         case "$filename" in
@@ -193,6 +193,8 @@ analyze_pax_contents() {
                 has_libexec=true ;;
             data/* | */data/*)
                 has_data=true ;;
+            usr/lpp/* | */usr/lpp/*)
+                is_os_layout=true ;;
         esac
     done << EOF
 $pax_listing
@@ -222,15 +224,52 @@ generate_install_commands() {
     cat << 'EOF'
 # Install files into FHS-like filesystem hierarchy under /opt/pkg/
 
-# zopen tool archives always extract to a single top-level directory
-# (e.g. curl-8.10.1/) containing bin/, lib/, etc. cd into it.
-SUB_DIR=$(find . -maxdepth 1 -mindepth 1 -type d | head -1)
-if [ -z "$SUB_DIR" ]; then
-    echo "ERROR: could not find top-level directory in extracted archive" >&2
-    exit 1
+# Detect the source layout and find the content root
+if [ -d usr ]; then
+    echo "OS layout (usr/) detected, searching for actual package root..."
+    # Strategy: find the shallowest directory whose parent contains at least
+    # one *binary/library* FHS child (bin, lib, libexec, include, altbin).
+    # We intentionally exclude 'share', 'etc', and 'man' as anchors because
+    # these exist at the OS level (e.g. usr/share/) and would incorrectly
+    # select 'usr' instead of the real package root deeper in the tree
+    # (e.g. usr/lpp/foo/ which contains the actual bin/ and lib/).
+    ROOT_DIR=""
+    ROOT_DIR=$(find . -type d \( \
+            -name bin -o -name lib -o -name libexec -o \
+            -name include -o -name altbin -o \
+            -name pyz -o -name bash -o -name go \) -print | \
+        sed 's|/[^/]*$||' | \
+        sed 's|^\./||' | \
+        sort -u | \
+        awk -F/ '{ print NF" "$0 }' | \
+        sort -n -k1,1 -k2 | \
+        awk 'NR==1{ sub(/^[0-9]+ /,""); print }')
+
+    if [ -z "$ROOT_DIR" ] || [ "$ROOT_DIR" = "." ]; then
+        # Fallback: walk down single-child directories until we find a
+        # directory with more than one entry (the real content root).
+        # Use find instead of ls -1 so dotfiles are counted correctly.
+        ROOT_DIR="."
+        while [ "$(find "$ROOT_DIR" -maxdepth 1 -mindepth 1 | wc -l)" -eq 1 ]; do
+            SUB_DIR=$(find "$ROOT_DIR" -maxdepth 1 -mindepth 1)
+            if [ -d "$SUB_DIR" ]; then
+                ROOT_DIR="$SUB_DIR"
+            else
+                break
+            fi
+        done
+    fi
+    echo "Detected package root: $ROOT_DIR"
+    cd "$ROOT_DIR" || { echo "ERROR: could not cd into $ROOT_DIR" >&2; exit 1; }
+elif [ "$(find . -maxdepth 1 -mindepth 1 -type d | wc -l)" -eq 1 ]; then
+    # Standard single-directory layout (e.g., curl-8.10.1/)
+    SUB_DIR=$(find . -maxdepth 1 -mindepth 1 -type d)
+    echo "Standard single-directory layout detected: $SUB_DIR"
+    cd "$SUB_DIR" || { echo "ERROR: could not cd into $SUB_DIR" >&2; exit 1; }
+else
+    # Flat layout — bin/, lib/, etc. at root, already in the right place
+    echo "Flat layout detected"
 fi
-echo "Entering package root: $SUB_DIR"
-cd "$SUB_DIR" || { echo "ERROR: could not cd into $SUB_DIR" >&2; exit 1; }
 
 # Distribute known directories to their FHS-correct paths
 for dir in bin altbin lib libexec include etc share man doc docs scripts data; do

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -250,18 +250,18 @@ if [ -d usr ]; then
     fi
     echo "Detected nested root: $ROOT_DIR"
     mkdir -p %{buildroot}%{install_dir}
-    cp -RP "$ROOT_DIR"/* %{buildroot}%{install_dir}/
+    (cd "$ROOT_DIR" && pax -rw -p p . %{buildroot}%{install_dir}/)
 elif [ $(ls -1 | grep -v "^$" | wc -l) -eq 1 ] && [ -d * ]; then
     # Standard single-directory layout (e.g., go/)
     SUB_DIR=$(ls -1)
     echo "Standard single-directory layout detected: $SUB_DIR"
     mkdir -p %{buildroot}%{install_dir}
-    cp -RP "$SUB_DIR"/* %{buildroot}%{install_dir}/
+    (cd "$SUB_DIR" && pax -rw -p p . %{buildroot}%{install_dir}/)
 else
     # Flat or mixed layout
     echo "Flat or mixed layout detected"
     mkdir -p %{buildroot}%{install_dir}
-    cp -RP * %{buildroot}%{install_dir}/
+    (pax -rw -p p . %{buildroot}%{install_dir}/)
 fi
 
 # Install root-level documentation if it hasn't been copied already
@@ -269,7 +269,7 @@ fi
 for doc in README* LICENSE* COPYING* CHANGELOG* AUTHORS* INSTALL* NEWS*; do
     if [ -f "$doc" ]; then
         mkdir -p %{buildroot}%{install_dir}/doc
-        cp -RP "$doc" %{buildroot}%{install_dir}/doc/
+        pax -rw -p p "$doc" %{buildroot}%{install_dir}/doc/
     fi
 done
 EOF


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [x] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->
1. Replace cp -RP with pax -rw -p p in the install commands to preserve hardlinks during RPM build. cp -RP breaks hardlinks into independent copies, which inflates RPM size for packages like git that hardlink ~150+ commands to a single binary. With this fix, the git RPM is reduced from ~900MB to ~70MB.
2. Correct the install command in publish script

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
