### PR TITLE
feat(tools): add zopen-rpmbuild to handle rpmbuild and signing

### DIFF
--- a/.github/workflows/rpm_build_and_test.yml
+++ b/.github/workflows/rpm_build_and_test.yml
@@ -30,6 +30,8 @@ jobs:
       spec_file: ${{ inputs.spec_file }}
       no_promote: true
       context_name: "RPM Build and Test"
+      github_event_name: ${{ github.event_name }}
+      pr_url: ${{ github.event.issue.pull_request.url || github.event.pull_request.url }}
     secrets:
       JENKINS_USER: ${{ secrets.JENKINS_USER }}
       JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}

--- a/.github/workflows/rpm_build_and_test.yml
+++ b/.github/workflows/rpm_build_and_test.yml
@@ -1,0 +1,35 @@
+name: "RPMBuildAndTest"
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: false
+        type: string
+        default: ""
+      branch:
+        required: false
+        default: ""
+        type: string
+      spec_file:
+        required: false
+        default: "build.spec"
+        type: string
+    secrets:
+      JENKINS_USER:
+        required: true
+      JENKINS_API_TOKEN:
+        required: true
+
+jobs:
+  test-run:
+    uses: ./.github/workflows/rpm_workflow.yml
+    with:
+      repo: ${{ inputs.repo }}
+      branch: ${{ inputs.branch }}
+      spec_file: ${{ inputs.spec_file }}
+      no_promote: true
+      context_name: "RPM Build and Test"
+    secrets:
+      JENKINS_USER: ${{ secrets.JENKINS_USER }}
+      JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}

--- a/.github/workflows/rpm_release.yml
+++ b/.github/workflows/rpm_release.yml
@@ -30,6 +30,8 @@ jobs:
       spec_file: ${{ inputs.spec_file }}
       no_promote: false
       context_name: "RPM Release and Publish"
+      github_event_name: ${{ github.event_name }}
+      pr_url: ${{ github.event.issue.pull_request.url || github.event.pull_request.url }}
     secrets:
       JENKINS_USER: ${{ secrets.JENKINS_USER }}
       JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}

--- a/.github/workflows/rpm_release.yml
+++ b/.github/workflows/rpm_release.yml
@@ -1,0 +1,35 @@
+name: "RPMRelease"
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: false
+        type: string
+        default: ""
+      branch:
+        required: false
+        default: "main"
+        type: string
+      spec_file:
+        required: false
+        default: "build.spec"
+        type: string
+    secrets:
+      JENKINS_USER:
+        required: true
+      JENKINS_API_TOKEN:
+        required: true
+
+jobs:
+  release-run:
+    uses: ./.github/workflows/rpm_workflow.yml
+    with:
+      repo: ${{ inputs.repo }}
+      branch: ${{ inputs.branch }}
+      spec_file: ${{ inputs.spec_file }}
+      no_promote: false
+      context_name: "RPM Release and Publish"
+    secrets:
+      JENKINS_USER: ${{ secrets.JENKINS_USER }}
+      JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}

--- a/.github/workflows/rpm_workflow.yml
+++ b/.github/workflows/rpm_workflow.yml
@@ -1,0 +1,152 @@
+name: "RPMWorkflowCore"
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: false
+        type: string
+        default: ""
+      branch:
+        required: false
+        default: ""
+        type: string
+      spec_file:
+        required: false
+        default: "build.spec"
+        type: string
+      no_promote:
+        required: true
+        type: boolean
+      context_name:
+        required: true
+        type: string
+    secrets:
+      JENKINS_USER:
+        required: true
+      JENKINS_API_TOKEN:
+        required: true
+
+jobs:
+  trigger-jenkins-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR details
+        if: ${{ github.event_name == 'issue_comment'}}
+        uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+
+      - name: Set commit status as pending
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha || github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+          context: "${{ inputs.context_name }}"
+
+      - name: Github API Request
+        id: request
+        if: ${{ github.event_name != 'push' }}
+        uses: octokit/request-action@v2.x
+        with:
+          route: |
+            ${{ github.event.issue.pull_request.url || github.event.pull_request.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger Jenkins Job
+        run: |
+          repo="${{ inputs.repo }}"
+          if [ -z "${repo}" ]; then
+            if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              repo="${{ github.event.repository.clone_url }}"
+            else
+              repo="${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
+            fi
+          fi
+          branch="${{ inputs.branch }}"
+          if [ -z "${branch}" ]; then
+            if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              branch="${{ github.ref_name }}"
+            else
+              branch="${{ fromJson(steps.request.outputs.data).head.ref }}"
+            fi
+          fi
+          
+          echo "=========================================="
+          echo " Triggering Jenkins Pipeline"
+          echo " Target Repo : ${repo}"
+          echo " Target Branch: ${branch}"
+          echo " Spec File   : ${{ inputs.spec_file }}"
+          echo " No Promote  : ${{ inputs.no_promote }}"
+          echo "=========================================="
+
+          CAUSE="Triggered by GH Action: Repo ${repo}, Branch: ${branch}"
+          ENCODED_CAUSE=$(echo -n "$CAUSE" | jq -s -R -r @uri)
+          
+          # Target the new RPM-Pipeline orchestrator job
+          JENKINS_JOB_URL="${{ vars.JENKINS_HOST_URL }}/job/RPM-Pipeline/buildWithParameters?token=jenkinstest&cause=${ENCODED_CAUSE}"
+
+          RESPONSE=$(curl -k -X POST -s -i -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" "${JENKINS_JOB_URL}" \
+            -F PROJECT_GITHUB_REPO="${repo}" \
+            -F PROJECT_BRANCH="${branch}" \
+            -F SPEC_FILE="${{ inputs.spec_file }}" \
+            -F NO_PROMOTE="${{ inputs.no_promote }}" \
+            -F PORT_DESCRIPTION="CI run for ${repo}")
+
+          # Extract the build URL from the response headers
+          BUILD_URL=$(echo "$RESPONSE" | grep -oP "location: \K(.*)" | tr -d '\r')
+
+          # Extract the build number from the BUILD_URL
+          BUILD_NUMBER=$(basename "$BUILD_URL" | tr -d '/')
+          echo "Build Number: $BUILD_NUMBER"
+
+          # Poll the Jenkins queue API to check if the job has started
+          while [ "$(curl -k -s --header 'content-type: nocache' --header 'Accept: application/json' "${{ vars.JENKINS_HOST_URL }}/queue/item/${BUILD_NUMBER}/api/json" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" | jq -r '.executable.number')" == "null" ]; do
+              echo "Job is waiting in the queue..."
+              sleep 10
+          done
+
+          # Retrieve the build URL once the job has started
+          BUILD_NUMBER=$(curl -k -s --header 'Accept: application/json' "${{ vars.JENKINS_HOST_URL }}/queue/item/${BUILD_NUMBER}/api/json" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" | jq -r '.executable.number')
+          echo "Job Number: $BUILD_NUMBER"
+
+          echo "Build in progress..."
+          echo "See ${{ vars.JENKINS_HOST_URL }}/job/RPM-Pipeline/${BUILD_NUMBER}/console for more details (if you have access)"
+          
+          # Poll the Jenkins API to check if the build has completed
+          while true; do
+            set +e
+            CURL_OUTPUT=$(curl -k -s -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" --header 'content-type: nocache' --header 'Accept: application/json' "${{ vars.JENKINS_HOST_URL }}/job/RPM-Pipeline/${BUILD_NUMBER}/api/json" --fail)
+            if [ $? -gt 0 ]; then
+              sleep 30
+              echo "Previous curl command failed, retrying..."
+              CURL_OUTPUT=$(curl -k -s -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" --header 'User-Agent: Mozilla/5.0' --header 'Accept: application/json' "${{ vars.JENKINS_HOST_URL }}/job/RPM-Pipeline/${BUILD_NUMBER}/api/json" --fail)
+            fi
+            set -e
+            if [ "$(echo "${CURL_OUTPUT}" | jq -r '.building')" != "true" ]; then
+              break;
+            fi
+            stdbuf -o0 printf "."
+            sleep 10
+          done
+          echo ""
+          echo "Console output: "
+          
+          # Retrieve the console output of the Jenkins job
+          curl -k -s --header 'User-Agent: Mozilla/5.0' "${{ vars.JENKINS_HOST_URL }}/job/RPM-Pipeline/${BUILD_NUMBER}/consoleText" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
+
+          if [ "$(curl -k -s --header 'User-Agent: Mozilla/5.0' --header 'Accept: application/json' "${{ vars.JENKINS_HOST_URL }}/job/RPM-Pipeline/${BUILD_NUMBER}/api/json" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" | jq -r '.result')" != "SUCCESS" ]; then
+            echo "Job failed..."
+            exit 1
+          fi
+          exit 0
+
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        if: always()
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha || github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          context: "${{ inputs.context_name }}"

--- a/.github/workflows/rpm_workflow.yml
+++ b/.github/workflows/rpm_workflow.yml
@@ -21,6 +21,13 @@ on:
       context_name:
         required: true
         type: string
+      github_event_name:
+        required: true
+        type: string
+      pr_url:
+        required: false
+        type: string
+        default: ""
     secrets:
       JENKINS_USER:
         required: true
@@ -32,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get PR details
-        if: ${{ github.event_name == 'issue_comment'}}
+        if: ${{ inputs.github_event_name == 'issue_comment'}}
         uses: xt0rted/pull-request-comment-branch@v1
         id: comment-branch
 
@@ -46,11 +53,11 @@ jobs:
 
       - name: Github API Request
         id: request
-        if: ${{ github.event_name != 'push' }}
+        if: ${{ inputs.github_event_name != 'push' && inputs.github_event_name != 'workflow_dispatch' }}
         uses: octokit/request-action@v2.x
         with:
           route: |
-            ${{ github.event.issue.pull_request.url || github.event.pull_request.url }}
+            GET ${{ inputs.pr_url }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -58,7 +65,7 @@ jobs:
         run: |
           repo="${{ inputs.repo }}"
           if [ -z "${repo}" ]; then
-            if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ inputs.github_event_name }}" = "push" ] || [ "${{ inputs.github_event_name }}" = "workflow_dispatch" ]; then
               repo="${{ github.event.repository.clone_url }}"
             else
               repo="${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
@@ -66,7 +73,7 @@ jobs:
           fi
           branch="${{ inputs.branch }}"
           if [ -z "${branch}" ]; then
-            if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ inputs.github_event_name }}" = "push" ] || [ "${{ inputs.github_event_name }}" = "workflow_dispatch" ]; then
               branch="${{ github.ref_name }}"
             else
               branch="${{ fromJson(steps.request.outputs.data).head.ref }}"
@@ -94,8 +101,15 @@ jobs:
             -F NO_PROMOTE="${{ inputs.no_promote }}" \
             -F PORT_DESCRIPTION="CI run for ${repo}")
 
-          # Extract the build URL from the response headers
-          BUILD_URL=$(echo "$RESPONSE" | grep -oP "location: \K(.*)" | tr -d '\r')
+          # Extract the build URL from the response headers (case-insensitive location match)
+          BUILD_URL=$(echo "$RESPONSE" | grep -ioP "location: \K(.*)" | tr -d '\r')
+
+          if [ -z "$BUILD_URL" ]; then
+            echo "ERROR: Failed to trigger Jenkins job or retrieve Queue Location URL." >&2
+            echo "HTTP Response was:" >&2
+            echo "$RESPONSE" >&2
+            exit 1
+          fi
 
           # Extract the build number from the BUILD_URL
           BUILD_NUMBER=$(basename "$BUILD_URL" | tr -d '/')

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2592,18 +2592,14 @@ package()
   if [ -n "${ZOPEN_INSTALL_CMD}" ]; then
     #TODO: Hack so that we can use coreutils md5sum without impacting builds
     ZOPEN_DEPS="coreutils jq"
-    if [ "${signPax}" = "true" ] || [ "${signRPM}" = "true" ]; then
+    if [ "${signPax}" = "true" ]; then
       if ( [ -z "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ -z "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ] ); then
-        printError "GPG keyring environment variables are not set! You can omit the --sign-pax or --sign-rpm option to bypass this"
+        printError "GPG keyring environment variables are not set! You can omit the --sign-pax option to bypass this"
       fi
-      if [ "${signPax}" = "true" ] && ( [ -z "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] ); then
+      if [ -z "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ] || [ ! -r "${ZOPEN_GPG_PUBLIC_KEY_FILE}" ]; then
         printError "ZOPEN_GPG_PUBLIC_KEY_FILE not set or not readable! Required for PAX signing."
       fi
       ZOPEN_DEPS="${ZOPEN_DEPS} gpg"
-    fi
-
-    if ${generateRPM}; then
-      ZOPEN_DEPS="${ZOPEN_DEPS} rpm"
     fi
 
     setDepsEnv ${ZOPEN_DEPS}

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -74,7 +74,7 @@ Options:
   --build                 Build the RPM after generating spec file (binary + source)
   --build-binary          Build binary RPM only (faster, no source RPM)
   --buildroot <dir>       RPM build root directory (default: ~/rpmbuild)
-  --validate              Validate spec file after generation (checks syntax and runs rpmlint)
+  --validate              Validate spec file after generation (checks syntax using rpmbuild -bp)
   --dry-run               Show what would be done without actually doing it
   --verbose               Enable verbose debug output
   --help                  Display this help message
@@ -512,44 +512,6 @@ EOF
 
 # sign_rpm and setup_rpmbuild have been moved to zopen-rpmbuild.
 
-# Function to check for required tools
-check_required_tools() {
-    missing_tools=""
-    # pax is always needed by zopen-pax2rpm
-    if ! command -v pax > /dev/null 2>&1; then
-        missing_tools="${missing_tools} pax"
-    fi
-
-    if [ -n "$missing_tools" ]; then
-        echo "" >&2
-        printError "Missing required tools:"
-        for tool in $missing_tools; do
-            echo "  ✗ $tool" >&2
-            case "$tool" in
-                pax)
-                    echo "    Purpose: Extract pax archives" >&2
-                    echo "    Install: Usually pre-installed on z/OS" >&2
-                    echo "             On Linux: apt-get install pax" >&2
-                    ;;
-            esac
-            echo "" >&2
-        done
-        printInfo "Please install the missing tools and try again."
-        return 1
-    fi
-
-    # Optional tools check (informational only)
-    if [ "$VALIDATE_SPEC" = true ] && ! command -v rpmlint > /dev/null 2>&1; then
-        echo "" >&2
-        echo "Note: rpmlint not found — spec quality checks will be limited." >&2
-        echo "      Install: On z/OS: zopen install rpmlint" >&2
-        echo "               On Linux: apt-get install rpmlint" >&2
-        echo "" >&2
-    fi
-
-    return 0
-}
-
 # Function to validate spec file syntax
 validate_spec_syntax() {
     spec_file="$1"
@@ -590,48 +552,6 @@ validate_spec_syntax() {
     fi
 }
 
-# Function to run rpmlint on spec file
-run_rpmlint() {
-    spec_file="$1"
-
-    echo ""
-    echo "=========================================="
-    echo "Running rpmlint checks..."
-    echo "=========================================="
-    echo ""
-
-    # Check if rpmlint is available
-    if ! command -v rpmlint > /dev/null 2>&1; then
-        echo "Note: rpmlint not found, skipping quality checks"
-        echo "Install rpmlint for additional spec file validation"
-        return 0
-    fi
-
-    # Run rpmlint
-    rpmlint_output=$(rpmlint "$spec_file" 2>&1 || true)
-    rpmlint_exit=$?
-    
-    echo "$rpmlint_output"
-    echo ""
-
-    # Count errors and warnings
-    errors=$(echo "$rpmlint_output" | grep -c "E:" || true)
-    warnings=$(echo "$rpmlint_output" | grep -c "W:" || true)
-
-    if [ $errors -gt 0 ]; then
-        echo "⚠ Found $errors error(s) and $warnings warning(s)"
-        echo "Please review and fix errors before building"
-        return 1
-    elif [ $warnings -gt 0 ]; then
-        echo "⚠ Found $warnings warning(s)"
-        echo "Warnings can often be ignored, but please review them"
-        return 0
-    else
-        echo "✓ No errors or warnings found"
-        return 0
-    fi
-}
-
 # Function to validate generated spec file
 validate_spec_file() {
 spec_file="$1"
@@ -658,11 +578,6 @@ source_name=$(basename "$pax_file")
     
     # Check syntax
     if ! validate_spec_syntax "$spec_file" "$buildroot"; then
-        validation_failed=true
-    fi
-    
-    # Run rpmlint
-    if ! run_rpmlint "$spec_file"; then
         validation_failed=true
     fi
     
@@ -706,14 +621,14 @@ pax_file="$1"
     echo "3. Generate spec file: $OUTPUT_FILE"
     
     if [ "$VALIDATE_SPEC" = true ]; then
-        echo "4. Validate spec file syntax and run rpmlint"
+        echo "4. Validate spec file syntax"
     fi
     
     if [ "$BUILD_RPM" = true ]; then
         echo "5. Build RPM package in: $BUILDROOT"
         echo "   - Copy $pax_file to $BUILDROOT/SOURCES/"
         echo "   - Copy spec file to $BUILDROOT/SPECS/"
-        echo "   - Run: rpmbuild --define \"_topdir $BUILDROOT\" -ba $OUTPUT_FILE"
+        echo "   - Run: zopen-rpmbuild \"$OUTPUT_FILE\" --source \"$pax_file\" --buildroot \"$BUILDROOT\""
     fi
     
     echo ""
@@ -896,11 +811,7 @@ main() {
     # Normalize version for RPM compatibility: strip optional v/V prefix and convert pre-release suffixes
     PKG_VERSION=$(normalizeRpmVersion "$PKG_VERSION")
     
-    # Check for required tools (pax is always needed; rpmbuild is handled by zopen-rpmbuild)
-    if ! check_required_tools; then
-        exit 1
-    fi
-    
+
     # Display extracted information
     echo "Package Information:"
     echo "  Name:        $PKG_NAME"

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -46,6 +46,9 @@ VALIDATE_SPEC=false
 DRY_RUN=false
 VERBOSE=false
 
+# Path to the companion build/sign script
+ZOPEN_RPMBUILD="${MYDIR}/zopen-rpmbuild"
+
 # Function to display usage
 usage() {
 exit_code="${1:-1}"
@@ -507,203 +510,43 @@ EOF
     return 0
 }
 
-# Function to sign generated RPMs
-sign_rpm() {
-    buildroot="$1"
-    
-    # Check for required environment variables
-    if [ -z "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || [ -z "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ]; then
-        printError "Signing requested but ZOPEN_GPG_SECRET_KEY_FILE or ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE not set"
-        return 1
-    fi
-
-    echo ""
-    echo "=========================================="
-    echo "Signing RPM packages..."
-    echo "=========================================="
-    echo ""
-
-    # Create a temporary directory for GPG keyring using zopen_tmp_dir
-    if [ -z "${zopen_tmp_dir}" ] || [ ! -d "${zopen_tmp_dir}" ]; then
-        printError "zopen_tmp_dir not set or not a directory. Cannot create temporary GPG directory."
-    fi
-    TMP_GPG_DIR="${zopen_tmp_dir}/rpm_gpg_$$"
-    echo "Creating temporary GPG directory: ${TMP_GPG_DIR}"
-    if ! mkdir -p "${TMP_GPG_DIR}" 2>/dev/null; then
-        printError "Failed to create temporary directory for GPG signing"
-    fi
-    chmod 700 "${TMP_GPG_DIR}"
-    echo "Temporary GPG directory created"
-    
-    # Register cleanup trap
-    addCleanupTrapCmd "rm -rf ${TMP_GPG_DIR}"
-    echo "Cleanup trap registered"
-    
-    OLD_GNUPGHOME="$GNUPGHOME"
-    export GNUPGHOME="$TMP_GPG_DIR"
-    echo "GNUPGHOME set to: ${GNUPGHOME}"
-    RPM_LIST=""
-
-    # Import the private key
-    echo "Importing private key..."
-    if ! gpg --batch --yes --import "${ZOPEN_GPG_SECRET_KEY_FILE}" >/dev/null 2>&1; then
-        printError "Failed to import GPG secret key"
-    fi
-    echo "Private key imported successfully"
-
-    # Identify the GPG key ID (long ID)
-    echo "Extracting GPG key ID..."
-    GPG_KEY_ID=$(gpg --list-secret-keys --with-colons | grep '^sec' | cut -d: -f5 | head -n 1)
-    if [ -z "${GPG_KEY_ID}" ]; then
-        printError "Could not identify GPG key ID from imported key"
-    fi
-    echo "GPG key ID: ${GPG_KEY_ID}"
-
-    # Create a wrapper script for gpg to handle the passphrase file
-    echo "Creating GPG wrapper script..."
-    GPG_WRAPPER="${TMP_GPG_DIR}/gpg_wrapper.sh"
-    cat << EOF > "${GPG_WRAPPER}"
-#!/bin/sh
-gpg --batch --pinentry-mode loopback --passphrase-file "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" "\$@"
-EOF
-    chmod +x "${GPG_WRAPPER}"
-    echo "GPG wrapper script created"
-
-    # Sign the RPMs using the wrapper and key ID
-    # We use --define to override the GPG command and key details
-    SIGN_CMD="rpmsign --addsign --key-id ${GPG_KEY_ID} \
-        --define '_gpg_name ${GPG_KEY_ID}' \
-        --define '__gpg ${GPG_WRAPPER}' \
-        --define '_gpg_path ${TMP_GPG_DIR}'"
-
-    # Use a temporary file to avoid subshell return issues
-    echo "Finding RPM files to sign..."
-    RPM_LIST=$(mktempfile "rpmlist")
-    find "$buildroot/RPMS" -name "*.rpm" -type f > "$RPM_LIST"
-    
-    if [ ! -s "$RPM_LIST" ]; then
-        printError "No RPM packages found to sign in $buildroot/RPMS"
-    fi
-    
-    rpm_count=$(wc -l < "$RPM_LIST")
-    echo "Found ${rpm_count} RPM(s) to sign"
-
-    while read rpm; do
-        [ -z "$rpm" ] && continue
-        echo "Signing $rpm..."
-        if ! eval "${SIGN_CMD} \"${rpm}\""; then
-            printError "Failed to sign RPM: $rpm"
-        fi
-    done < "$RPM_LIST"
-
-    rm -f "$RPM_LIST"
-    rm -rf "$TMP_GPG_DIR"
-    [ -n "$OLD_GNUPGHOME" ] && export GNUPGHOME="$OLD_GNUPGHOME" || unset GNUPGHOME
-
-    echo "All RPMs signed successfully"
-    return 0
-}
-
-# Function to setup rpmbuild directories
-setup_rpmbuild() {
-buildroot="$1"
-    
-    echo "Setting up RPM build directories in: $buildroot"
-    
-    mkdir -p "$buildroot/BUILD" "$buildroot/BUILDROOT" "$buildroot/RPMS" "$buildroot/SOURCES" "$buildroot/SPECS" "$buildroot/SRPMS"
-    
-    if [ ! -f "$HOME/.rpmmacros" ]; then
-        if touch "$HOME/.rpmmacros" 2>/dev/null; then
-            cat > "$HOME/.rpmmacros" << EOF
-%_topdir $buildroot
-EOF
-            echo "Created ~/.rpmmacros with _topdir set to $buildroot"
-        else
-            echo "Warning: could not create ~/.rpmmacros. This is normal in some CI environments."
-            echo "The script will use '$buildroot' by overriding it with --define \"_topdir $buildroot\"."
-        fi
-    else
-        # Check if _topdir is already defined and different
-        existing_topdir=$(grep "%_topdir" "$HOME/.rpmmacros" | awk '{print $2}')
-        if [ -n "$existing_topdir" ] && [ "$existing_topdir" != "$buildroot" ]; then
-            echo "Warning: ~/.rpmmacros exists and has _topdir set to '$existing_topdir'."
-            echo "The script will use '$buildroot' by overriding it with --define \"_topdir $buildroot\"."
-        fi
-    fi
-}
+# sign_rpm and setup_rpmbuild have been moved to zopen-rpmbuild.
 
 # Function to check for required tools
 check_required_tools() {
     missing_tools=""
-    pax_file="$1"
-    
-    # Check for pax
+    # pax is always needed by zopen-pax2rpm
     if ! command -v pax > /dev/null 2>&1; then
         missing_tools="${missing_tools} pax"
     fi
-    
-    # Check for rpmbuild if building or validating
-    if [ "$BUILD_RPM" = true ] || [ "$VALIDATE_SPEC" = true ]; then
-        if [ "$VERBOSE" = true ]; then
-            echo "DEBUG: Current PATH is $PATH" >&2
-        fi
-        if ! command -v rpmbuild > /dev/null 2>&1; then
-            missing_tools="${missing_tools} rpmbuild"
-        fi
-    fi
-    
+
     if [ -n "$missing_tools" ]; then
         echo "" >&2
-        printError "Missing Required Tools"
-        echo "The following tools are required but not found:" >&2
-        echo "" >&2
-        
+        printError "Missing required tools:"
         for tool in $missing_tools; do
             echo "  ✗ $tool" >&2
-            
             case "$tool" in
                 pax)
                     echo "    Purpose: Extract pax archives" >&2
                     echo "    Install: Usually pre-installed on z/OS" >&2
-                    echo "             On Linux: apt-get install pax (Debian/Ubuntu/RHEL/CentOS)" >&2
-                    ;;
-                rpmbuild)
-                    echo "    Purpose: Build RPM packages and validate spec files" >&2
-                    echo "    Install: Part of rpm-build package" >&2
-                    echo "             On z/OS: zopen install rpm" >&2
-                    echo "             On Linux: apt-get install rpm (Debian/Ubuntu/RHEL/CentOS)" >&2
+                    echo "             On Linux: apt-get install pax" >&2
                     ;;
             esac
             echo "" >&2
         done
-        
         printInfo "Please install the missing tools and try again."
         return 1
     fi
-    
+
     # Optional tools check (informational only)
-    optional_missing=""
-    
     if [ "$VALIDATE_SPEC" = true ] && ! command -v rpmlint > /dev/null 2>&1; then
-        optional_missing="${optional_missing} rpmlint"
-    fi
-    
-    if [ -n "$optional_missing" ]; then
         echo "" >&2
-        echo "Note: Optional tools not found (validation will be limited):" >&2
-        for tool in $optional_missing; do
-            echo "  - $tool (for enhanced spec file quality checks)" >&2
-            case "$tool" in
-                rpmlint)
-                    echo "    Install: On z/OS: zopen install rpmlint" >&2
-                    echo "             On Linux: apt-get install rpmlint (Debian/Ubuntu)" >&2
-                    echo "                       yum install rpmlint (RHEL/CentOS)" >&2
-                    ;;
-            esac
-        done
+        echo "Note: rpmlint not found — spec quality checks will be limited." >&2
+        echo "      Install: On z/OS: zopen install rpmlint" >&2
+        echo "               On Linux: apt-get install rpmlint" >&2
         echo "" >&2
     fi
-    
+
     return 0
 }
 
@@ -801,9 +644,11 @@ validation_failed=false
     echo "Validating generated spec file..."
     echo "=========================================="
     
-    # Setup environment for validation (rpmbuild -bp needs source)
-    setup_rpmbuild "$buildroot"
-    
+    # Ensure SOURCES directory exists so rpmbuild -bp can find the source
+    mkdir -p "$buildroot/BUILD" "$buildroot/BUILDROOT" \
+             "$buildroot/RPMS"  "$buildroot/SOURCES"   \
+             "$buildroot/SPECS" "$buildroot/SRPMS"
+
     # Copy pax file to SOURCES if not already there
 source_name=$(basename "$pax_file")
     if [ ! -f "$buildroot/SOURCES/$source_name" ] || [ "$pax_file" -nt "$buildroot/SOURCES/$source_name" ]; then
@@ -876,86 +721,25 @@ pax_file="$1"
     echo ""
 }
 
-# Function to build RPM
+# Function to build (and optionally sign) an RPM by delegating to zopen-rpmbuild
 build_rpm() {
-spec_file="$1"
-pax_file="$2"
-buildroot="$3"
-    
-    echo ""
-    echo "=========================================="
-    echo "Building RPM package..."
-    echo "=========================================="
-    echo ""
-    
-    # Setup rpmbuild directories
-    setup_rpmbuild "$buildroot"
-    
-    # Copy pax file to SOURCES
-source_name=$(basename "$pax_file")
-    echo "Copying source file to $buildroot/SOURCES/$source_name"
-    cp "$pax_file" "$buildroot/SOURCES/"
+    spec_file="$1"
+    pax_file="$2"
+    buildroot="$3"
 
-    # Copy spec file to SPECS
-    echo "Copying spec file to $buildroot/SPECS/"
-    cp "$spec_file" "$buildroot/SPECS/"
-    
-    # Build the RPM
-    echo ""
-    if [ "$BUILD_BINARY_ONLY" = true ]; then
-        echo "Running rpmbuild --define \"_topdir $buildroot\" -bb $spec_file"
-        echo ""
-        rpmbuild_result=$(rpmbuild --define "_topdir $buildroot" -bb "$spec_file" 2>&1)
-        rpmbuild_exit=$?
-        echo "$rpmbuild_result"
-    else
-        echo "Running rpmbuild --define \"_topdir $buildroot\" -ba $spec_file"
-        echo ""
-        rpmbuild_result=$(rpmbuild --define "_topdir $buildroot" -ba "$spec_file" 2>&1)
-        rpmbuild_exit=$?
-        echo "$rpmbuild_result"
+    if [ ! -x "${ZOPEN_RPMBUILD}" ]; then
+        printError "Cannot find zopen-rpmbuild at '${ZOPEN_RPMBUILD}'. \
+Please ensure it is installed alongside zopen-pax2rpm."
     fi
-    
-    if [ $rpmbuild_exit -eq 0 ]; then
-        echo ""
-        echo "=========================================="
-        echo "✓ RPM build completed successfully!"
-        echo "=========================================="
-        echo ""
-        echo "Generated packages:"
-        echo ""
-        echo "Binary RPMs:"
-        find "$buildroot/RPMS" -name "*.rpm" -type f 2>/dev/null | while read rpm; do
-            echo "  - $rpm"
-        done
-        if [ "$BUILD_BINARY_ONLY" != true ]; then
-            echo ""
-            echo "Source RPMs:"
-            find "$buildroot/SRPMS" -name "*.rpm" -type f 2>/dev/null | while read rpm; do
-                echo "  - $rpm"
-            done
-        fi
-        echo ""
 
-        if [ "$SIGN_RPM" = true ]; then
-            sign_rpm "$buildroot"
-        fi
+    # Compose the zopen-rpmbuild command
+    rpmbuild_cmd="${ZOPEN_RPMBUILD} \"$spec_file\" --source \"$pax_file\" --buildroot \"$buildroot\""
+    [ "$BUILD_BINARY_ONLY" = true ] && rpmbuild_cmd="$rpmbuild_cmd --build-binary"
+    [ "$SIGN_RPM"          = true ] && rpmbuild_cmd="$rpmbuild_cmd --sign"
+    [ "$VERBOSE"           = true ] && rpmbuild_cmd="$rpmbuild_cmd --verbose"
 
-        return 0
-    else
-        echo ""
-        echo "=========================================="
-        echo "✗ RPM build failed!"
-        echo "=========================================="
-        echo ""
-        echo "Please review the spec file and build output above."
-        echo "Common issues:"
-        echo "  - Missing BuildRequires dependencies"
-        echo "  - Incorrect file paths in %install or %files sections"
-        echo "  - Pax extraction errors"
-        echo ""
-        return 1
-    fi
+    printInfo "Delegating to: $rpmbuild_cmd"
+    eval "$rpmbuild_cmd"
 }
 
 # Main script
@@ -1112,8 +896,8 @@ main() {
     # Normalize version for RPM compatibility: strip optional v/V prefix and convert pre-release suffixes
     PKG_VERSION=$(normalizeRpmVersion "$PKG_VERSION")
     
-    # Check for required tools
-    if ! check_required_tools "$PAX_FILE"; then
+    # Check for required tools (pax is always needed; rpmbuild is handled by zopen-rpmbuild)
+    if ! check_required_tools; then
         exit 1
     fi
     
@@ -1128,7 +912,8 @@ main() {
     echo "  Output:      $OUTPUT_FILE"
     echo ""
     
-    # Handle dry-run mode
+    # Handle dry-run mode — delegate build dry-run to zopen-rpmbuild so it is
+    # consistent with what would actually be executed.
     if [ "$DRY_RUN" = true ]; then
         perform_dry_run "$PAX_FILE"
         exit 0
@@ -1169,11 +954,9 @@ main() {
         echo "  2. Adjust the %install and %files sections if needed"
         if [ "$VALIDATE_SPEC" = false ]; then
             echo "  3. Validate the spec: $0 $PAX_FILE --summary \"$SUMMARY\" --validate"
-            echo "  4. Copy the pax file to rpmbuild/SOURCES/"
-            echo "  5. Build the RPM: rpmbuild --define \"_topdir $BUILDROOT\" -ba $OUTPUT_FILE"
+            echo "  4. Build the RPM:     zopen-rpmbuild $OUTPUT_FILE --source $PAX_FILE"
         else
-            echo "  3. Copy the pax file to rpmbuild/SOURCES/"
-            echo "  4. Build the RPM: rpmbuild --define \"_topdir $BUILDROOT\" -ba $OUTPUT_FILE"
+            echo "  3. Build the RPM:     zopen-rpmbuild $OUTPUT_FILE --source $PAX_FILE"
         fi
         echo ""
         echo "Or run with --build flag to build automatically:"

--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -732,14 +732,14 @@ build_rpm() {
 Please ensure it is installed alongside zopen-pax2rpm."
     fi
 
-    # Compose the zopen-rpmbuild command
-    rpmbuild_cmd="${ZOPEN_RPMBUILD} \"$spec_file\" --source \"$pax_file\" --buildroot \"$buildroot\""
-    [ "$BUILD_BINARY_ONLY" = true ] && rpmbuild_cmd="$rpmbuild_cmd --build-binary"
-    [ "$SIGN_RPM"          = true ] && rpmbuild_cmd="$rpmbuild_cmd --sign"
-    [ "$VERBOSE"           = true ] && rpmbuild_cmd="$rpmbuild_cmd --verbose"
+    # Build the zopen-rpmbuild argument list
+    set -- "$spec_file" --source "$pax_file" --buildroot "$buildroot"
+    [ "$BUILD_BINARY_ONLY" = true ] && set -- "$@" --build-binary
+    [ "$SIGN_RPM"          = true ] && set -- "$@" --sign
+    [ "$VERBOSE"           = true ] && set -- "$@" --verbose
 
-    printInfo "Delegating to: $rpmbuild_cmd"
-    eval "$rpmbuild_cmd"
+    printInfo "Delegating to: ${ZOPEN_RPMBUILD} $*"
+    "${ZOPEN_RPMBUILD}" "$@"
 }
 
 # Main script

--- a/bin/zopen-rpmbuild
+++ b/bin/zopen-rpmbuild
@@ -277,29 +277,68 @@ perform_dry_run()
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
+# setDepsEnv  — Simplified version for zopen-rpmbuild.
+# Installs a zopen dependency if not present and sources its .env.
+# ──────────────────────────────────────────────────────────────────────────────
+depsPath="${ZOPEN_PKGINSTALL}"
+
+# Find the directory containing a dependency's .env file in the depsPath
+find_dep_dir()
+{
+  _fd_name="$1"
+  for _fd_path in $(echo "${depsPath}" | tr '|' '\n'); do
+    _fd_dir="${_fd_path}/${_fd_name}/${_fd_name}"
+    if [ -r "${_fd_dir}/.env" ]; then
+      echo "${_fd_dir}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+setDepsEnv()
+{
+  if [ $# -eq 0 ]; then
+    return
+  fi
+
+  _sde_deps=$(normalizeDeps "$*")
+  _sde_orig="${PWD}"
+
+  for _sde_dep in ${_sde_deps}; do
+    _sde_name=$(parseDeps "${_sde_dep}" | cut -d'|' -f1)
+
+    # Install the dependency if not already found in depsPath
+    if ! find_dep_dir "${_sde_name}" >/dev/null; then
+      printWarning "Dependency ${_sde_name} not found. Downloading via zopen install"
+      if ! runAndLog "PATH=\"${ZOPEN_OLD_PATH}\" ${MYDIR}/zopen-install --install-or-upgrade ${_sde_name} -v -y"; then
+        printError "zopen install command failed"
+      fi
+    fi
+
+    # Locate and source the dependency environment
+    if _sde_dir=$(find_dep_dir "${_sde_name}"); then
+      printVerbose "Setting up ${_sde_name} dependency environment from ${_sde_dir}"
+      cd "${_sde_dir}" && . ./.env
+      if [ $? -gt 0 ]; then
+        printError "Failed to source ${_sde_dir}/.env"
+      fi
+    else
+      printError "Dependency ${_sde_name} not found for sourcing"
+    fi
+  done
+
+  cd "${_sde_orig}" || exit 99
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
 # setup_rpm_env  — ensure zopen rpm is installed and source its .env so
 # rpmbuild and brp-* scripts use GNU tools (e.g. xargs -0) on z/OS.
 # ──────────────────────────────────────────────────────────────────────────────
 setup_rpm_env()
 {
-  # ZOPEN_PKGINSTALL is set by common.sh (sourced via setupMyself)
-  RPM_ENV="${ZOPEN_PKGINSTALL}/rpm/rpm/.env"
-
-  # Install rpm via zopen if not already present
-  if [ ! -r "${RPM_ENV}" ]; then
-    printInfo "zopen rpm not found. Installing via zopen install..."
-    if ! zopen install rpm -y; then
-      printError "Failed to install rpm via zopen install"
-    fi
-  fi
-
-  # Source the rpm .env to put GNU tools on PATH
-  if [ -r "${RPM_ENV}" ]; then
-    printInfo "Sourcing zopen rpm environment: ${RPM_ENV}"
-    . "${RPM_ENV}"
-  else
-    printWarning "zopen rpm .env not found at ${RPM_ENV} — using system rpm"
-  fi
+  printInfo "Ensuring zopen rpm is installed and sourcing its environment..."
+  setDepsEnv rpm
 }
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/bin/zopen-rpmbuild
+++ b/bin/zopen-rpmbuild
@@ -277,6 +277,32 @@ perform_dry_run()
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
+# setup_rpm_env  — ensure zopen rpm is installed and source its .env so
+# rpmbuild and brp-* scripts use GNU tools (e.g. xargs -0) on z/OS.
+# ──────────────────────────────────────────────────────────────────────────────
+setup_rpm_env()
+{
+  # ZOPEN_PKGINSTALL is set by common.sh (sourced via setupMyself)
+  RPM_ENV="${ZOPEN_PKGINSTALL}/rpm/rpm/.env"
+
+  # Install rpm via zopen if not already present
+  if [ ! -r "${RPM_ENV}" ]; then
+    printInfo "zopen rpm not found. Installing via zopen install..."
+    if ! zopen install rpm -y; then
+      printError "Failed to install rpm via zopen install"
+    fi
+  fi
+
+  # Source the rpm .env to put GNU tools on PATH
+  if [ -r "${RPM_ENV}" ]; then
+    printInfo "Sourcing zopen rpm environment: ${RPM_ENV}"
+    . "${RPM_ENV}"
+  else
+    printWarning "zopen rpm .env not found at ${RPM_ENV} — using system rpm"
+  fi
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
 # do_build  — the actual rpmbuild invocation
 # ──────────────────────────────────────────────────────────────────────────────
 do_build()
@@ -284,6 +310,9 @@ do_build()
   spec_file="$1"
 
   printHeader "Building RPM package from spec: $spec_file"
+
+  # Source zopen rpm .env so rpmbuild and brp-* scripts use GNU tools
+  setup_rpm_env
 
   setup_rpmbuild "$BUILDROOT"
 

--- a/bin/zopen-rpmbuild
+++ b/bin/zopen-rpmbuild
@@ -12,7 +12,8 @@ setupMyself()
   ME=$(basename $0)
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
-  if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
+  ZOPEN_OLD_PATH="${PATH}"
+  if ! [ -d "${INCDIR}" ] || ! [ -f "${INCDIR}/common.sh" ]; then
     echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
@@ -213,18 +214,23 @@ check_required_tools()
     missing_tools="${missing_tools} rpmbuild"
   fi
 
-  if [ "$SIGN_RPM" = true ] && ! command -v gpg > /dev/null 2>&1; then
-    missing_tools="${missing_tools} gpg"
+  if [ "$SIGN_RPM" = true ]; then
+    if ! command -v gpg > /dev/null 2>&1; then
+      missing_tools="${missing_tools} gpg"
+    fi
+    if ! command -v rpmsign > /dev/null 2>&1; then
+      missing_tools="${missing_tools} rpmsign"
+    fi
   fi
 
   if [ -n "$missing_tools" ]; then
-    printError "Missing required tools:${missing_tools}"
+    echo "ERROR: Missing required tools:${missing_tools}" >&2
     for tool in $missing_tools; do
       case "$tool" in
-        rpmbuild)
-          echo "  rpmbuild: part of rpm-build package" >&2
-          echo "            On z/OS: zopen install rpm" >&2
-          echo "            On Linux: apt-get install rpm / yum install rpm-build" >&2
+        rpmbuild|rpmsign)
+          echo "  $tool: part of rpm-build / rpm-sign package" >&2
+          echo "         On z/OS: zopen install rpm" >&2
+          echo "         On Linux: apt-get install rpm-sign / yum install rpm-build" >&2
           ;;
         gpg)
           echo "  gpg: GNU Privacy Guard" >&2
@@ -337,8 +343,12 @@ setDepsEnv()
 # ──────────────────────────────────────────────────────────────────────────────
 setup_rpm_env()
 {
-  printInfo "Ensuring zopen rpm is installed and sourcing its environment..."
-  setDepsEnv rpm
+  printInfo "Ensuring required zopen packages are installed and sourced..."
+  _sre_deps="rpm"
+  if [ "$SIGN_RPM" = true ]; then
+    _sre_deps="${_sre_deps} gpg"
+  fi
+  setDepsEnv ${_sre_deps}
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -349,9 +359,6 @@ do_build()
   spec_file="$1"
 
   printHeader "Building RPM package from spec: $spec_file"
-
-  # Source zopen rpm .env so rpmbuild and brp-* scripts use GNU tools
-  setup_rpm_env
 
   setup_rpmbuild "$BUILDROOT"
 
@@ -499,6 +506,9 @@ main()
     perform_dry_run "$SPEC_FILE"
     exit 0
   fi
+
+  # Ensure dependencies (such as rpm) are installed and sourced before checking tools
+  setup_rpm_env
 
   # Check that required tools are present
   if ! check_required_tools; then

--- a/bin/zopen-rpmbuild
+++ b/bin/zopen-rpmbuild
@@ -1,0 +1,444 @@
+#!/bin/sh
+#
+# RPM build and signing utility for zopen
+# Accepts a pre-generated spec file and drives rpmbuild + optional GPG signing.
+#
+
+#
+# All zopen-* scripts MUST start with this code to maintain consistency.
+#
+setupMyself()
+{
+  ME=$(basename $0)
+  MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
+  INCDIR="${MYDIR}/../include"
+  if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
+    echo "Internal Error. Unable to find common.sh file to source." >&2
+    exit 8
+  fi
+  . "${INCDIR}/common.sh"
+}
+setupMyself
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Defaults
+# ──────────────────────────────────────────────────────────────────────────────
+BUILD_BINARY_ONLY=false
+SIGN_RPM=false
+BUILDROOT="${HOME}/rpmbuild"
+DRY_RUN=false
+VERBOSE=false
+# Extra source files to copy into SOURCES/ before building (space-separated)
+EXTRA_SOURCES=""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# usage
+# ──────────────────────────────────────────────────────────────────────────────
+usage()
+{
+  exit_code="${1:-1}"
+  cat << EOF
+Usage: $ME <spec_file> [options]
+
+Build an RPM package from an existing spec file, and optionally sign it.
+
+Works for both regular packages (with source files) and virtual/meta packages
+(spec files with no Source: tag and no %install/%files section).
+
+Arguments:
+  spec_file               Path to the RPM spec file to build
+
+Options:
+  --source <file>         Source file to copy into SOURCES/ before building.
+                          May be repeated for multiple source files.
+                          Omit entirely for virtual/meta packages that have
+                          no sources (e.g. dependency group packages).
+  --build-binary          Build binary RPM only (no source RPM, faster)
+  --buildroot <dir>       RPM build root directory (default: ~/rpmbuild)
+  --sign                  GPG-sign all generated RPM packages after a
+                          successful build.  Requires:
+                            ZOPEN_GPG_SECRET_KEY_FILE
+                            ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE
+  --dry-run               Show what would be done without doing it
+  --verbose               Enable verbose/debug output (set -x)
+  --help                  Display this help message
+  --version               Display tool version
+
+Environment (required for --sign):
+  ZOPEN_GPG_SECRET_KEY_FILE             Path to the GPG secret key (armored)
+  ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE  Path to a file containing the passphrase
+
+Examples:
+  # Build a virtual/meta package (no sources needed)
+  $ME meta-zopen-devtools.spec
+
+  # Build a regular package with a pax source file
+  $ME mypackage.spec --source /path/to/mypackage.pax.Z
+
+  # Build binary RPM only
+  $ME mypackage.spec --source /path/to/mypackage.pax.Z --build-binary
+
+  # Build and sign
+  $ME mypackage.spec --source /path/to/mypackage.pax.Z --sign
+
+  # Multiple source files
+  $ME mypackage.spec --source pkg.pax.Z --source extra-data.tar.gz
+
+EOF
+  exit "$exit_code"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# setup_rpmbuild  — create the standard rpmbuild directory tree and ~/.rpmmacros
+# ──────────────────────────────────────────────────────────────────────────────
+setup_rpmbuild()
+{
+  buildroot="$1"
+
+  printInfo "Setting up RPM build directories in: $buildroot"
+  mkdir -p "$buildroot/BUILD" "$buildroot/BUILDROOT" \
+           "$buildroot/RPMS"  "$buildroot/SOURCES"   \
+           "$buildroot/SPECS" "$buildroot/SRPMS"
+
+  if [ ! -f "$HOME/.rpmmacros" ]; then
+    if touch "$HOME/.rpmmacros" 2>/dev/null; then
+      cat > "$HOME/.rpmmacros" << EOF
+%_topdir $buildroot
+EOF
+      printInfo "Created ~/.rpmmacros with _topdir set to $buildroot"
+    else
+      printWarning "Could not create ~/.rpmmacros. Will pass --define \"_topdir $buildroot\" to rpmbuild."
+    fi
+  else
+    existing_topdir=$(grep "%_topdir" "$HOME/.rpmmacros" | awk '{print $2}')
+    if [ -n "$existing_topdir" ] && [ "$existing_topdir" != "$buildroot" ]; then
+      printWarning "~/.rpmmacros has _topdir='$existing_topdir'; overriding with --define \"_topdir $buildroot\"."
+    fi
+  fi
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# sign_rpm  — GPG-sign every RPM under buildroot/RPMS/
+# ──────────────────────────────────────────────────────────────────────────────
+sign_rpm()
+{
+  buildroot="$1"
+
+  # Validate required env vars
+  if [ -z "${ZOPEN_GPG_SECRET_KEY_FILE}" ] || \
+     [ -z "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" ]; then
+    printError "Signing requested but ZOPEN_GPG_SECRET_KEY_FILE or \
+ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE is not set"
+    return 1
+  fi
+
+  printHeader "Signing RPM packages..."
+
+  # Temporary isolated GPG home
+  if [ -z "${zopen_tmp_dir}" ] || [ ! -d "${zopen_tmp_dir}" ]; then
+    printError "zopen_tmp_dir is not set or is not a directory. Cannot create temporary GPG directory."
+  fi
+  TMP_GPG_DIR="${zopen_tmp_dir}/rpm_gpg_$$"
+  if ! mkdir -p "${TMP_GPG_DIR}" 2>/dev/null; then
+    printError "Failed to create temporary GPG directory: ${TMP_GPG_DIR}"
+  fi
+  chmod 700 "${TMP_GPG_DIR}"
+  addCleanupTrapCmd "rm -rf ${TMP_GPG_DIR}"
+
+  OLD_GNUPGHOME="$GNUPGHOME"
+  export GNUPGHOME="$TMP_GPG_DIR"
+
+  # Import private key
+  printInfo "Importing GPG private key..."
+  if ! gpg --batch --yes --import "${ZOPEN_GPG_SECRET_KEY_FILE}" >/dev/null 2>&1; then
+    printError "Failed to import GPG secret key from ${ZOPEN_GPG_SECRET_KEY_FILE}"
+  fi
+
+  # Extract key ID
+  GPG_KEY_ID=$(gpg --list-secret-keys --with-colons | grep '^sec' | cut -d: -f5 | head -n 1)
+  if [ -z "${GPG_KEY_ID}" ]; then
+    printError "Could not determine GPG key ID from imported key"
+  fi
+  printInfo "Using GPG key ID: ${GPG_KEY_ID}"
+
+  # Passphrase wrapper
+  GPG_WRAPPER="${TMP_GPG_DIR}/gpg_wrapper.sh"
+  cat << WRAPPER_EOF > "${GPG_WRAPPER}"
+#!/bin/sh
+gpg --batch --pinentry-mode loopback \
+    --passphrase-file "${ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE}" "\$@"
+WRAPPER_EOF
+  chmod +x "${GPG_WRAPPER}"
+
+  SIGN_CMD="rpmsign --addsign --key-id ${GPG_KEY_ID} \
+    --define '_gpg_name ${GPG_KEY_ID}' \
+    --define '__gpg ${GPG_WRAPPER}' \
+    --define '_gpg_path ${TMP_GPG_DIR}'"
+
+  RPM_LIST=$(mktempfile "rpmlist")
+  find "$buildroot/RPMS" -name "*.rpm" -type f > "$RPM_LIST"
+
+  if [ ! -s "$RPM_LIST" ]; then
+    rm -f "$RPM_LIST"
+    printError "No RPM packages found to sign under $buildroot/RPMS"
+  fi
+
+  rpm_count=$(wc -l < "$RPM_LIST")
+  printInfo "Signing ${rpm_count} RPM(s)..."
+
+  while IFS= read -r rpm; do
+    [ -z "$rpm" ] && continue
+    printInfo "  Signing: $rpm"
+    if ! eval "${SIGN_CMD} \"${rpm}\""; then
+      rm -f "$RPM_LIST"
+      printError "Failed to sign RPM: $rpm"
+    fi
+  done < "$RPM_LIST"
+
+  rm -f "$RPM_LIST"
+  rm -rf "$TMP_GPG_DIR"
+  [ -n "$OLD_GNUPGHOME" ] && export GNUPGHOME="$OLD_GNUPGHOME" || unset GNUPGHOME
+
+  printInfo "All RPMs signed successfully."
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# check_required_tools
+# ──────────────────────────────────────────────────────────────────────────────
+check_required_tools()
+{
+  missing_tools=""
+
+  if ! command -v rpmbuild > /dev/null 2>&1; then
+    missing_tools="${missing_tools} rpmbuild"
+  fi
+
+  if [ "$SIGN_RPM" = true ] && ! command -v gpg > /dev/null 2>&1; then
+    missing_tools="${missing_tools} gpg"
+  fi
+
+  if [ -n "$missing_tools" ]; then
+    printError "Missing required tools:${missing_tools}"
+    for tool in $missing_tools; do
+      case "$tool" in
+        rpmbuild)
+          echo "  rpmbuild: part of rpm-build package" >&2
+          echo "            On z/OS: zopen install rpm" >&2
+          echo "            On Linux: apt-get install rpm / yum install rpm-build" >&2
+          ;;
+        gpg)
+          echo "  gpg: GNU Privacy Guard" >&2
+          echo "       On z/OS: zopen install gpg" >&2
+          echo "       On Linux: apt-get install gnupg / yum install gnupg2" >&2
+          ;;
+      esac
+    done
+    return 1
+  fi
+  return 0
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# perform_dry_run
+# ──────────────────────────────────────────────────────────────────────────────
+perform_dry_run()
+{
+  spec_file="$1"
+
+  printHeader "DRY RUN MODE — no files will be created or modified"
+  echo ""
+  echo "Would perform the following actions:"
+  echo ""
+  echo "1. Set up rpmbuild tree in:  $BUILDROOT"
+  if [ -n "$EXTRA_SOURCES" ]; then
+    step=2
+    for src in $EXTRA_SOURCES; do
+      echo "$step. Copy source file:         $src -> $BUILDROOT/SOURCES/"
+      step=$((step + 1))
+    done
+  else
+    echo "   (no source files — virtual/meta package)"
+    step=2
+  fi
+  echo "$step. Copy spec file:           $spec_file -> $BUILDROOT/SPECS/"
+  step=$((step + 1))
+  if [ "$BUILD_BINARY_ONLY" = true ]; then
+    echo "$step. Run: rpmbuild --define \"_topdir $BUILDROOT\" -bb $spec_file"
+  else
+    echo "$step. Run: rpmbuild --define \"_topdir $BUILDROOT\" -ba $spec_file"
+  fi
+  if [ "$SIGN_RPM" = true ]; then
+    step=$((step + 1))
+    echo "$step. GPG-sign all generated RPMs"
+  fi
+  echo ""
+  echo "To execute, re-run without --dry-run."
+  echo ""
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# do_build  — the actual rpmbuild invocation
+# ──────────────────────────────────────────────────────────────────────────────
+do_build()
+{
+  spec_file="$1"
+
+  printHeader "Building RPM package from spec: $spec_file"
+
+  setup_rpmbuild "$BUILDROOT"
+
+  # Copy any extra source files into SOURCES/
+  for src in $EXTRA_SOURCES; do
+    src_name=$(basename "$src")
+    printInfo "Copying source file: $src -> $BUILDROOT/SOURCES/$src_name"
+    cp "$src" "$BUILDROOT/SOURCES/"
+  done
+
+  # Copy spec file into SPECS/
+  printInfo "Copying spec file to $BUILDROOT/SPECS/"
+  cp "$spec_file" "$BUILDROOT/SPECS/"
+
+  # Run rpmbuild
+  if [ "$BUILD_BINARY_ONLY" = true ]; then
+    printInfo "Running: rpmbuild --define \"_topdir $BUILDROOT\" -bb $spec_file"
+    rpmbuild --define "_topdir $BUILDROOT" -bb "$spec_file"
+    rpmbuild_exit=$?
+  else
+    printInfo "Running: rpmbuild --define \"_topdir $BUILDROOT\" -ba $spec_file"
+    rpmbuild --define "_topdir $BUILDROOT" -ba "$spec_file"
+    rpmbuild_exit=$?
+  fi
+
+  if [ $rpmbuild_exit -eq 0 ]; then
+    printHeader "RPM build completed successfully!"
+    echo ""
+    echo "Generated binary RPMs:"
+    find "$BUILDROOT/RPMS" -name "*.rpm" -type f 2>/dev/null | while IFS= read -r rpm; do
+      echo "  $rpm"
+    done
+    if [ "$BUILD_BINARY_ONLY" != true ]; then
+      echo ""
+      echo "Generated source RPMs:"
+      find "$BUILDROOT/SRPMS" -name "*.rpm" -type f 2>/dev/null | while IFS= read -r rpm; do
+        echo "  $rpm"
+      done
+    fi
+    echo ""
+
+    if [ "$SIGN_RPM" = true ]; then
+      sign_rpm "$BUILDROOT"
+    fi
+
+    return 0
+  else
+    printError "rpmbuild failed (exit $rpmbuild_exit). Review the output above for details."
+  fi
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# main
+# ──────────────────────────────────────────────────────────────────────────────
+main()
+{
+  if [ $# -eq 0 ]; then
+    usage
+  fi
+
+  # Handle bare --help / --version before positional arg parsing
+  case "$1" in
+    --help)
+      usage 0
+      ;;
+    --version)
+      if [ -x "${MYDIR}/zopen-version" ]; then
+        "${MYDIR}/zopen-version" "${ME}"
+      else
+        echo "${ME} version $(cat "${INCDIR}/zopen_version" 2>/dev/null || echo "unknown")"
+      fi
+      exit 0
+      ;;
+  esac
+
+  SPEC_FILE="$1"
+  shift
+
+  # Validate spec file exists
+  if [ ! -f "$SPEC_FILE" ]; then
+    printError "Spec file not found: $SPEC_FILE"
+  fi
+
+  # Parse remaining options
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --source)
+        [ -n "$2" ] || { echo "Error: --source requires a value" >&2; usage; }
+        if [ -n "$EXTRA_SOURCES" ]; then
+          EXTRA_SOURCES="$EXTRA_SOURCES $2"
+        else
+          EXTRA_SOURCES="$2"
+        fi
+        shift 2
+        ;;
+      --build-binary)
+        BUILD_BINARY_ONLY=true
+        shift
+        ;;
+      --buildroot)
+        [ -n "$2" ] || { echo "Error: --buildroot requires a value" >&2; usage; }
+        BUILDROOT="$2"
+        shift 2
+        ;;
+      --sign)
+        SIGN_RPM=true
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --verbose)
+        VERBOSE=true
+        set -x
+        shift
+        ;;
+      --help)
+        usage 0
+        ;;
+      --version)
+        if [ -x "${MYDIR}/zopen-version" ]; then
+          "${MYDIR}/zopen-version" "${ME}"
+        else
+          echo "${ME} version $(cat "${INCDIR}/zopen_version" 2>/dev/null || echo "unknown")"
+        fi
+        exit 0
+        ;;
+      *)
+        echo "Error: Unknown option: $1" >&2
+        usage
+        ;;
+    esac
+  done
+
+  # Validate extra source files exist
+  for src in $EXTRA_SOURCES; do
+    if [ ! -f "$src" ]; then
+      printError "Source file not found: $src"
+    fi
+  done
+
+  # Dry-run — just describe what would happen and exit
+  if [ "$DRY_RUN" = true ]; then
+    perform_dry_run "$SPEC_FILE"
+    exit 0
+  fi
+
+  # Check that required tools are present
+  if ! check_required_tools; then
+    exit 1
+  fi
+
+  # Build (and optionally sign)
+  do_build "$SPEC_FILE"
+}
+
+main "$@"

--- a/cicd/publish_rpm.groovy
+++ b/cicd/publish_rpm.groovy
@@ -40,10 +40,10 @@ node('linux') {
                   projectName: 'RPM-Build',
                   selector: selectorObj
 
-    // Verify we actually have RPMs to publish
-    def numRpms = sh(script: 'find rpms/ -name "*.rpm" | wc -l', returnStdout: true).trim().toInteger()
+    // Verify we actually have RPMs to publish (excluding source RPMs)
+    def numRpms = sh(script: 'find rpms/ -name "*.rpm" ! -name "*.src.rpm" | wc -l', returnStdout: true).trim().toInteger()
     if (numRpms == 0) {
-      error "No RPM files found to publish in the copied artifacts (rpms/)"
+      error "No binary RPM files found to publish in the copied artifacts (rpms/)"
     }
     
     echo "Found ${numRpms} RPMs to publish."
@@ -97,14 +97,16 @@ node('linux') {
                 break
               fi
               if [ "\$attempt" -eq 3 ]; then
-                echo "WARNING: Failed to upload \$RPM_NAME to Pulp after 3 attempts."
+                echo "ERROR: Failed to upload \$RPM_NAME to Pulp after 3 attempts."
+                exit 1
               else
                 sleep 5
               fi
             done
           done
         else
-          echo "WARNING: Pulp CLI not available, skipping RPM upload"
+          echo "ERROR: Pulp CLI is not available. Aborting publish run." >&2
+          exit 1
         fi
       """
     }

--- a/cicd/publish_rpm.groovy
+++ b/cicd/publish_rpm.groovy
@@ -1,0 +1,113 @@
+// Inputs:
+//   PORT_GITHUB_REPO      : GitHub repo (e.g. https://github.com/zopencommunity/base-os.git)
+//   BUILD_SELECTOR        : Jenkins build selector XML to copy artifacts from the build job
+
+def project_repo    = params.PORT_GITHUB_REPO     ?: ""
+def build_selector  = params.BUILD_SELECTOR       ?: ""
+
+node('linux') {
+
+  def ws = env.WORKSPACE
+  
+  stage('Setup') {
+    deleteDir()
+    checkout scm
+
+    // Determine the build selector. Supports Copy Artifact XML string from parameter widget, raw build numbers, or lastSuccessful fallback.
+    def selectorObj
+    if (build_selector) {
+      if (build_selector.contains('SpecificBuildSelector')) {
+        // Extract build number from XML: <buildNumber>123</buildNumber>
+        def matcher = (build_selector =~ /<buildNumber>(.*?)<\/buildNumber>/)
+        if (matcher.find()) {
+          selectorObj = specific(matcher.group(1))
+        } else {
+          selectorObj = lastSuccessful()
+        }
+      } else if (build_selector.contains('StatusBuildSelector')) {
+        selectorObj = lastSuccessful()
+      } else if (build_selector == 'latest' || build_selector == 'lastSuccessful') {
+        selectorObj = lastSuccessful()
+      } else {
+        selectorObj = specific(build_selector)
+      }
+    } else {
+      selectorObj = lastSuccessful()
+    }
+
+    copyArtifacts filter: 'rpms/**/*.rpm',
+                  fingerprintArtifacts: true,
+                  projectName: 'RPM-Build',
+                  selector: selectorObj
+
+    // Verify we actually have RPMs to publish
+    def numRpms = sh(script: 'find rpms/ -name "*.rpm" | wc -l', returnStdout: true).trim().toInteger()
+    if (numRpms == 0) {
+      error "No RPM files found to publish in the copied artifacts (rpms/)"
+    }
+    
+    echo "Found ${numRpms} RPMs to publish."
+  }
+
+  stage('Pulp Upload') {
+    withCredentials([
+      string(credentialsId: 'PULP_USERNAME', variable: 'PULP_USERNAME'),
+      string(credentialsId: 'PULP_PASSWORD', variable: 'PULP_PASSWORD')
+    ]) {
+      sh """#!/bin/bash
+        set -euo pipefail
+
+        # Locate RPM files
+        RPM_FILES=()
+        while IFS= read -r -d '' f; do
+          RPM_FILES+=("\$f")
+        done < <(find rpms/ -name "*.rpm" ! -name "*.src.rpm" -type f -print0 2>/dev/null)
+
+        NUM_RPMS=\${#RPM_FILES[@]}
+        PULP_HOST="https://repo.zopen.community"
+        PULP_REPO="zopen"
+
+        # Verify pulp CLI is installed
+        if ! command -v pulp >/dev/null 2>&1; then
+          if command -v pip3 >/dev/null 2>&1; then
+            python3 -m pip install --user pulp-cli || true
+            export PATH="\$HOME/.local/bin:\$PATH"
+          fi
+        fi
+
+        if command -v pulp >/dev/null 2>&1; then
+          pulp config create \
+            --base-url "\${PULP_HOST}" \
+            --username "\${PULP_USERNAME}" \
+            --password "\${PULP_PASSWORD}" \
+            --overwrite
+
+          pulp status || { echo "ERROR: Pulp connection failed"; exit 1; }
+
+          echo "--- Configuring Pulp Pipeline ---"
+          pulp rpm repository update --name "\${PULP_REPO}" --autopublish
+          pulp rpm distribution update --name "\${PULP_REPO}" --repository "\${PULP_REPO}"
+
+          echo "Uploading \${NUM_RPMS} RPMs to Pulp repo: \${PULP_REPO}"
+          for RPM in "\${RPM_FILES[@]}"; do
+            RPM_NAME=\$(basename "\$RPM")
+            for attempt in 1 2 3; do
+              if pulp rpm content upload --file "\$RPM" --repository "\${PULP_REPO}"; then
+                echo "SUCCESS: \$RPM_NAME"
+                break
+              fi
+              if [ "\$attempt" -eq 3 ]; then
+                echo "WARNING: Failed to upload \$RPM_NAME to Pulp after 3 attempts."
+              else
+                sleep 5
+              fi
+            done
+          done
+        else
+          echo "WARNING: Pulp CLI not available, skipping RPM upload"
+        fi
+      """
+    }
+  }
+
+}

--- a/cicd/rpm_pipeline.jenkins
+++ b/cicd/rpm_pipeline.jenkins
@@ -1,0 +1,95 @@
+// Inputs:
+//   PROJECT_GITHUB_REPO   : Github repository (e.g. https://github.com/zopencommunity/base-os.git)
+//   PROJECT_BRANCH        : (default: main)
+//   SPEC_FILE             : Path to spec file relative to project root (default: build.spec)
+//   SOURCE_FILE           : Optional source file path relative to project root (e.g. mypackage.pax.Z)
+//   PORT_DESCRIPTION      : Description of the project
+//   BUILD_BINARY          : Boolean - build binary RPM only, skip source RPM (default: true)
+//   SIGN_RPM              : Boolean - GPG-sign generated RPMs after build (default: true)
+//   BUILDROOT             : RPM build root directory (default: ~/rpmbuild)
+//   NODE_LABEL            : Label of the Jenkins node to run on (default: zos)
+//   NO_PROMOTE            : Boolean, if true, avoid promotion (default: false)
+
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+
+@NonCPS
+String getLogFromRunWrapper(RunWrapper runWrapper, int logLines) {
+    runWrapper.getRawBuild().getLog(logLines).join('\n')
+}
+
+def repo = params.get("PROJECT_GITHUB_REPO")
+def branch = params.get("PROJECT_BRANCH") ?: "main"
+def spec_file = params.get("SPEC_FILE") ?: "build.spec"
+def source_file = params.get("SOURCE_FILE") ?: ""
+def description = params.get("PORT_DESCRIPTION")
+def buildroot = params.get("BUILDROOT") ?: ""
+def build_binary = params.get("BUILD_BINARY") != null ? params.get("BUILD_BINARY") : true
+def sign_rpm = params.get("SIGN_RPM") != null ? params.get("SIGN_RPM") : true
+def node_label = params.get("NODE_LABEL") ?: "zos"
+
+RunWrapper buildResult;
+RunWrapper promoteResult;
+
+node('linux')
+{
+  stage('RPM Build') {
+    // Build Job: RPM-Build
+    buildResult = build job: 'RPM-Build', propagate: false, parameters: [
+      string(name: 'PROJECT_GITHUB_REPO', value: "${repo}"),
+      string(name: 'PROJECT_BRANCH', value: "${branch}"),
+      string(name: 'SPEC_FILE', value: "${spec_file}"),
+      string(name: 'SOURCE_FILE', value: "${source_file}"),
+      string(name: 'BUILDROOT', value: "${buildroot}"),
+      booleanParam(name: 'BUILD_BINARY', value: build_binary),
+      booleanParam(name: 'SIGN_RPM', value: sign_rpm),
+      string(name: 'NODE_LABEL', value: "${node_label}")
+    ]
+    
+    def result = buildResult.getResult()
+    if(result == "FAILURE"){
+      handleError("RPM Build stage failed. View details in ${buildResult.absoluteUrl}", repo, getLogFromRunWrapper(buildResult, 50));
+    }
+  }
+  
+  stage('Promote') {
+    if(!params.NO_PROMOTE) {
+      // Publish Job: RPM-Publish
+      promoteResult = build job: 'RPM-Publish', propagate: false, parameters: [
+        string(name: 'BUILD_SELECTOR', value: buildResult.number.toString()),
+        string(name: 'PORT_GITHUB_REPO', value: "${repo}"),
+        string(name: 'PORT_DESCRIPTION', value: "${description}"),
+        string(name: 'BUILD_LINE', value: "STABLE") // Default build line for promotion
+      ]
+      
+      def result = promoteResult.getResult()
+      if(result == "FAILURE"){
+        handleError("Promote stage failed. View details in ${promoteResult.absoluteUrl}", repo, getLogFromRunWrapper(promoteResult, 50));
+      }
+    }
+  }
+
+  stage('Cleanup') {
+    def extraText = ""
+    if (params.NO_PROMOTE) {
+      extraText = "\nBuilt with NO_PROMOTE set to true."
+    } else {
+      extraText = "\nRPM packages successfully promoted to Pulp package repository."
+    }
+
+    slackSend color: 'good', 
+      message: "RPM Build Pipeline for ${repo} *successful* <${currentBuild.absoluteUrl}|Build #${currentBuild.number}>${extraText}"
+  }
+}
+
+def handleError(reason, repo, output="none") {
+  def message = "RPM Build Pipeline for ${repo}:\n<${currentBuild.absoluteUrl}|Build #${currentBuild.number}> *Failed*\n*Reason:* ${reason}\nLast 50 lines of output:\n```${output}```"
+  def attachments = [
+    [
+      text: message,
+      fallback: 'Fallback',
+      color: 'danger'
+    ]
+  ]
+  slackSend(attachments: attachments)
+  error "Job failed..."
+}

--- a/cicd/rpm_pipeline.jenkins
+++ b/cicd/rpm_pipeline.jenkins
@@ -46,7 +46,7 @@ node('linux')
     ]
     
     def result = buildResult.getResult()
-    if(result == "FAILURE"){
+    if(result != "SUCCESS"){
       handleError("RPM Build stage failed. View details in ${buildResult.absoluteUrl}", repo, getLogFromRunWrapper(buildResult, 50));
     }
   }
@@ -62,7 +62,7 @@ node('linux')
       ]
       
       def result = promoteResult.getResult()
-      if(result == "FAILURE"){
+      if(result != "SUCCESS"){
         handleError("Promote stage failed. View details in ${promoteResult.absoluteUrl}", repo, getLogFromRunWrapper(promoteResult, 50));
       }
     }

--- a/cicd/rpm_pipeline.jenkins
+++ b/cicd/rpm_pipeline.jenkins
@@ -69,27 +69,25 @@ node('linux')
   }
 
   stage('Cleanup') {
-    def extraText = ""
-    if (params.NO_PROMOTE) {
-      extraText = "\nBuilt with NO_PROMOTE set to true."
-    } else {
-      extraText = "\nRPM packages successfully promoted to Pulp package repository."
+    if (!params.NO_PROMOTE) {
+      def extraText = "\nRPM packages successfully promoted to Pulp package repository."
+      slackSend color: 'good', 
+        message: "RPM Build Pipeline for ${repo} *successful* <${currentBuild.absoluteUrl}|Build #${currentBuild.number}>${extraText}"
     }
-
-    slackSend color: 'good', 
-      message: "RPM Build Pipeline for ${repo} *successful* <${currentBuild.absoluteUrl}|Build #${currentBuild.number}>${extraText}"
   }
 }
 
 def handleError(reason, repo, output="none") {
   def message = "RPM Build Pipeline for ${repo}:\n<${currentBuild.absoluteUrl}|Build #${currentBuild.number}> *Failed*\n*Reason:* ${reason}\nLast 50 lines of output:\n```${output}```"
-  def attachments = [
-    [
-      text: message,
-      fallback: 'Fallback',
-      color: 'danger'
+  if (!params.NO_PROMOTE) {
+    def attachments = [
+      [
+        text: message,
+        fallback: 'Fallback',
+        color: 'danger'
+      ]
     ]
-  ]
-  slackSend(attachments: attachments)
+    slackSend(attachments: attachments)
+  }
   error "Job failed..."
 }

--- a/cicd/rpmbuild.groovy
+++ b/cicd/rpmbuild.groovy
@@ -27,96 +27,81 @@ def sign_rpm       = params.SIGN_RPM             ?: true
 def gpg_key_cred   = params.GPG_KEY_CREDENTIAL   ?: "ZOPEN_GPG_SECRET_KEY_FILE"
 def gpg_pass_cred  = params.GPG_PASS_CREDENTIAL  ?: "ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE"
 
-// Helper to run a bash script — writes content to a temp file and
-// invokes bash explicitly so z/OS sh is bypassed entirely.
-def runBash(script) {
-  sh "bash -xe -c '${script.replace("'", "'\\''")}'"
-}
-
 node(node_label) {
 
   def ws = env.WORKSPACE
 
-  // Common environment setup sourced at the start of every bash invocation
-  def envSetup = """
-    set +e
-    . /jenkins/.env
-    set -e
-    export PATH="${ws}/bin:\$PATH"
-    export NO_COLOR=1
-    export ZOPEN_IS_BOT=1
-    export GIT_UTF8_CCSID=819
-    export TMPDIR="${ws}/tmp"
-    mkdir -p "\$TMPDIR"
-  """
-
-  stage('Setup') {
-    deleteDir()
-    checkout scm
-    sh "bash -xe '${ws}/bin/zopen-rpmbuild' --version || true"
-    sh """bash -xe -s << 'BASH'
-${envSetup}
-echo "Setup complete. PATH=\$PATH"
-BASH"""
-  }
-
-  stage('Checkout') {
+  stage('Build RPM') {
     if (!project_repo) {
       error "PROJECT_GITHUB_REPO is required"
     }
 
     def project_name = project_repo.tokenize('/').last().replaceAll('\\.git$', '')
 
-    sh """bash -xe -s << 'BASH'
-${envSetup}
-git clone -b '${project_branch}' '${project_repo}' '${project_name}'
-BASH"""
+    // Set default buildroot as the cloned project repository directory inside the workspace
+    def localBuildroot = buildroot ?: "${ws}/${project_name}/rpmbuild"
 
-    env.PROJECT_NAME = project_name
-  }
-
-  stage('RPM Build') {
-    dir("${ws}/${env.PROJECT_NAME}") {
-
-      def cmd = "zopen-rpmbuild \"${spec_file}\""
-
-      if (source_file) {
-        cmd += " --source \"${source_file}\""
-      }
-
-      if (buildroot) {
-        cmd += " --buildroot \"${buildroot}\""
-      }
-
-      if (build_binary) {
-        cmd += " --build-binary"
-      }
-
-      cmd += " --verbose"
-
-      if (sign_rpm) {
-        withCredentials([
-          file(credentialsId: gpg_key_cred,  variable: 'ZOPEN_GPG_SECRET_KEY_FILE'),
-          file(credentialsId: gpg_pass_cred, variable: 'ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE')
-        ]) {
-          sh """bash -xe -s << 'BASH'
-${envSetup}
-${cmd} --sign
-BASH"""
-        }
-      } else {
-        sh """bash -xe -s << 'BASH'
-${envSetup}
-${cmd}
-BASH"""
-      }
+    // Construct the zopen-rpmbuild command options
+    def cmdOptions = "\"${spec_file}\" --buildroot \"${localBuildroot}\""
+    if (source_file) {
+      cmdOptions += " --source \"${source_file}\""
     }
-  }
+    if (build_binary) {
+      cmdOptions += " --build-binary"
+    }
 
-  stage('Archive') {
-    def rpmDir = buildroot ? "${buildroot}/RPMS" : "${env.HOME}/rpmbuild/RPMS"
+    // Run everything in a single, robust bash execution
+    deleteDir()
+    checkout scm
 
-    archiveArtifacts artifacts: "${rpmDir}/**/*.rpm",
+    // Construct sign flag for command execution
+    if (sign_rpm) {
+      cmdOptions += " --sign"
+    }
+
+    // Set up dynamic credentials mapping based on sign_rpm parameter
+    def gpgBindings = sign_rpm ? [
+      file(credentialsId: gpg_key_cred,  variable: 'ZOPEN_GPG_SECRET_KEY_FILE'),
+      file(credentialsId: gpg_pass_cred, variable: 'ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE')
+    ] : []
+
+    withCredentials(gpgBindings) {
+      sh """bash -e -s << 'BASH'
+        set +e
+        . /jenkins/.env
+        set -e
+        export PATH="${ws}/bin:\$PATH"
+        export NO_COLOR=1
+        export ZOPEN_IS_BOT=1
+        export GIT_UTF8_CCSID=819
+        export TMPDIR="${ws}/tmp"
+        export GPG_TTY="/dev/null"
+        mkdir -p "\$TMPDIR"
+
+        # 1. Print version diagnostics
+        zopen-rpmbuild --version || true
+
+        # 2. Clone repo clean
+        rm -rf "${project_name}"
+        git clone -b "${project_branch}" "${project_repo}" "${project_name}"
+
+        # 3. Verify spec file exists
+        if [ ! -f "${project_name}/${spec_file}" ]; then
+          echo "ERROR: Spec file not found in repository: ${project_name}/${spec_file}" >&2
+          exit 1
+        fi
+
+        # 4. Build
+        cd "${project_name}"
+        zopen-rpmbuild ${cmdOptions}
+
+        # 5. Copy RPMs to workspace for archiving
+        mkdir -p "${ws}/rpms"
+        cp -R "${localBuildroot}/RPMS/"* "${ws}/rpms/" 2>/dev/null || true
+BASH"""
+    }
+
+    archiveArtifacts artifacts: "rpms/**/*.rpm",
                      allowEmptyArchive: false,
                      fingerprint: true
   }

--- a/cicd/rpmbuild.groovy
+++ b/cicd/rpmbuild.groovy
@@ -1,0 +1,124 @@
+// RPM Build Job
+// Runs zopen-rpmbuild against a spec file from a given GitHub project repo.
+// meta.git is shallow cloned (depth=1) by Jenkins SCM config.
+// This job must run on the z/OS zot system.
+//
+// Inputs:
+//   PROJECT_GITHUB_REPO   : GitHub repo containing build.spec (e.g. https://github.com/zopencommunity/myport.git)
+//   PROJECT_BRANCH        : Branch to checkout (default: main)
+//   SPEC_FILE             : Path to spec file relative to project root (default: build.spec)
+//   SOURCE_FILE           : Optional source file path relative to project root (e.g. mypackage.pax.Z)
+//                           Leave empty for virtual/meta packages with no sources
+//   BUILD_BINARY          : Boolean - build binary RPM only, skip source RPM (default: true)
+//   SIGN_RPM              : Boolean - GPG-sign generated RPMs after build (default: true)
+//   BUILDROOT             : RPM build root directory (default: ~/rpmbuild)
+//   NODE_LABEL            : Label of the Jenkins node to run on (default: zos)
+//   GPG_KEY_CREDENTIAL    : Jenkins credential ID for GPG secret key file (default: ZOPEN_GPG_SECRET_KEY_FILE)
+//   GPG_PASS_CREDENTIAL   : Jenkins credential ID for GPG passphrase file (default: ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE)
+
+def node_label     = params.NODE_LABEL           ?: "zos"
+def project_repo   = params.PROJECT_GITHUB_REPO  ?: ""
+def project_branch = params.PROJECT_BRANCH       ?: "main"
+def spec_file      = params.SPEC_FILE            ?: "build.spec"
+def source_file    = params.SOURCE_FILE          ?: ""
+def buildroot      = params.BUILDROOT            ?: ""
+def build_binary   = params.BUILD_BINARY         ?: true
+def sign_rpm       = params.SIGN_RPM             ?: true
+def gpg_key_cred   = params.GPG_KEY_CREDENTIAL   ?: "ZOPEN_GPG_SECRET_KEY_FILE"
+def gpg_pass_cred  = params.GPG_PASS_CREDENTIAL  ?: "ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE"
+
+// Helper to run a bash script — writes content to a temp file and
+// invokes bash explicitly so z/OS sh is bypassed entirely.
+def runBash(script) {
+  sh "bash -xe -c '${script.replace("'", "'\\''")}'"
+}
+
+node(node_label) {
+
+  def ws = env.WORKSPACE
+
+  // Common environment setup sourced at the start of every bash invocation
+  def envSetup = """
+    set +e
+    . /jenkins/.env
+    set -e
+    export PATH="${ws}/bin:\$PATH"
+    export NO_COLOR=1
+    export ZOPEN_IS_BOT=1
+    export GIT_UTF8_CCSID=819
+    export TMPDIR="${ws}/tmp"
+    mkdir -p "\$TMPDIR"
+  """
+
+  stage('Setup') {
+    deleteDir()
+    checkout scm
+    sh "bash -xe '${ws}/bin/zopen-rpmbuild' --version || true"
+    sh """bash -xe -s << 'BASH'
+${envSetup}
+echo "Setup complete. PATH=\$PATH"
+BASH"""
+  }
+
+  stage('Checkout') {
+    if (!project_repo) {
+      error "PROJECT_GITHUB_REPO is required"
+    }
+
+    def project_name = project_repo.tokenize('/').last().replaceAll('\\.git$', '')
+
+    sh """bash -xe -s << 'BASH'
+${envSetup}
+git clone -b '${project_branch}' '${project_repo}' '${project_name}'
+BASH"""
+
+    env.PROJECT_NAME = project_name
+  }
+
+  stage('RPM Build') {
+    dir("${ws}/${env.PROJECT_NAME}") {
+
+      def cmd = "zopen-rpmbuild \"${spec_file}\""
+
+      if (source_file) {
+        cmd += " --source \"${source_file}\""
+      }
+
+      if (buildroot) {
+        cmd += " --buildroot \"${buildroot}\""
+      }
+
+      if (build_binary) {
+        cmd += " --build-binary"
+      }
+
+      cmd += " --verbose"
+
+      if (sign_rpm) {
+        withCredentials([
+          file(credentialsId: gpg_key_cred,  variable: 'ZOPEN_GPG_SECRET_KEY_FILE'),
+          file(credentialsId: gpg_pass_cred, variable: 'ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE')
+        ]) {
+          sh """bash -xe -s << 'BASH'
+${envSetup}
+${cmd} --sign
+BASH"""
+        }
+      } else {
+        sh """bash -xe -s << 'BASH'
+${envSetup}
+${cmd}
+BASH"""
+      }
+    }
+  }
+
+  stage('Archive') {
+    def rpmDir = buildroot ? "${buildroot}/RPMS" : "${env.HOME}/rpmbuild/RPMS"
+
+    archiveArtifacts artifacts: "${rpmDir}/**/*.rpm",
+                     allowEmptyArchive: false,
+                     fingerprint: true
+  }
+
+}

--- a/cicd/rpmbuild.groovy
+++ b/cicd/rpmbuild.groovy
@@ -22,8 +22,8 @@ def project_branch = params.PROJECT_BRANCH       ?: "main"
 def spec_file      = params.SPEC_FILE            ?: "build.spec"
 def source_file    = params.SOURCE_FILE          ?: ""
 def buildroot      = params.BUILDROOT            ?: ""
-def build_binary   = params.BUILD_BINARY         ?: true
-def sign_rpm       = params.SIGN_RPM             ?: true
+def build_binary   = params.BUILD_BINARY != null ? params.BUILD_BINARY : true
+def sign_rpm       = params.SIGN_RPM != null     ? params.SIGN_RPM     : true
 def gpg_key_cred   = params.GPG_KEY_CREDENTIAL   ?: "ZOPEN_GPG_SECRET_KEY_FILE"
 def gpg_pass_cred  = params.GPG_PASS_CREDENTIAL  ?: "ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE"
 
@@ -65,40 +65,59 @@ node(node_label) {
       file(credentialsId: gpg_pass_cred, variable: 'ZOPEN_GPG_SECRET_KEY_PASSPHRASE_FILE')
     ] : []
 
-    withCredentials(gpgBindings) {
-      sh """bash -e -s << 'BASH'
-        set +e
-        . /jenkins/.env
-        set -e
-        export PATH="${ws}/bin:\$PATH"
-        export NO_COLOR=1
-        export ZOPEN_IS_BOT=1
-        export GIT_UTF8_CCSID=819
-        export TMPDIR="${ws}/tmp"
-        export GPG_TTY="/dev/null"
-        mkdir -p "\$TMPDIR"
+    // Define the build commands closure
+    def runBuild = {
+      withEnv([
+        "PROJECT_REPO=${project_repo}",
+        "PROJECT_BRANCH=${project_branch}",
+        "PROJECT_NAME=${project_name}",
+        "SPEC_FILE=${spec_file}",
+        "LOCAL_BUILDROOT=${localBuildroot}",
+        "CMD_OPTIONS=${cmdOptions}"
+      ]) {
+        sh '''bash -e -s << \'BASH\'
+          set +e
+          . /jenkins/.env
+          set -e
+          export PATH="${WORKSPACE}/bin:$PATH"
+          export NO_COLOR=1
+          export ZOPEN_IS_BOT=1
+          export GIT_UTF8_CCSID=819
+          export TMPDIR="${WORKSPACE}/tmp"
+          export GPG_TTY="/dev/null"
+          mkdir -p "$TMPDIR"
 
-        # 1. Print version diagnostics
-        zopen-rpmbuild --version || true
+          # 1. Print version diagnostics
+          zopen-rpmbuild --version || true
 
-        # 2. Clone repo clean
-        rm -rf "${project_name}"
-        git clone -b "${project_branch}" "${project_repo}" "${project_name}"
+          # 2. Clone repo clean
+          rm -rf "${PROJECT_NAME}"
+          git clone -b "${PROJECT_BRANCH}" "${PROJECT_REPO}" "${PROJECT_NAME}"
 
-        # 3. Verify spec file exists
-        if [ ! -f "${project_name}/${spec_file}" ]; then
-          echo "ERROR: Spec file not found in repository: ${project_name}/${spec_file}" >&2
-          exit 1
-        fi
+          # 3. Verify spec file exists
+          if [ ! -f "${PROJECT_NAME}/${SPEC_FILE}" ]; then
+            echo "ERROR: Spec file not found in repository: ${PROJECT_NAME}/${SPEC_FILE}" >&2
+            exit 1
+          fi
 
-        # 4. Build
-        cd "${project_name}"
-        zopen-rpmbuild ${cmdOptions}
+          # 4. Build
+          cd "${PROJECT_NAME}"
+          eval "zopen-rpmbuild ${CMD_OPTIONS}"
 
-        # 5. Copy RPMs to workspace for archiving
-        mkdir -p "${ws}/rpms"
-        cp -R "${localBuildroot}/RPMS/"* "${ws}/rpms/" 2>/dev/null || true
-BASH"""
+          # 5. Copy binary and source RPMs to workspace for archiving
+          mkdir -p "${WORKSPACE}/rpms"
+          cp -R "${LOCAL_BUILDROOT}/RPMS/"* "${WORKSPACE}/rpms/" 2>/dev/null || true
+          cp -R "${LOCAL_BUILDROOT}/SRPMS/"* "${WORKSPACE}/rpms/" 2>/dev/null || true
+BASH'''
+      }
+    }
+
+    if (sign_rpm) {
+      withCredentials(gpgBindings) {
+        runBuild()
+      }
+    } else {
+      runBuild()
     }
 
     archiveArtifacts artifacts: "rpms/**/*.rpm",


### PR DESCRIPTION
Refactor rpmbuild and signing out of zopen-pax2rpm into a new standalone script zopen-rpmbuild, which takes a spec file as input. This allows it to be used independently, including for building virtual/meta RPM packages with no source files.

<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [ ] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
