### PR TITLE
Add opt-in Python wheel publishing pipeline

### DIFF
--- a/bin/zopen-generate
+++ b/bin/zopen-generate
@@ -775,6 +775,10 @@ createCICD() {
   buildline=$1; touch "${name}port/cicd-${buildline}.groovy" && chtag -tc 819 "${name}port/cicd-${buildline}.groovy"
   buildlineUpper=$(echo "${buildline}" | awk '{print toupper($0)}')
   _groovy_description=$(echo "$description" | sed "s/'/\"/g")
+  publish_python_wheel=false
+  if [ "${build_system}" = "Python" ] && [ "${buildline}" = "stable" ]; then
+    publish_python_wheel=true
+  fi
   cat << EOT > "${name}port/cicd-${buildline}.groovy"
 node('linux') {
   stage ('Poll') {
@@ -786,7 +790,8 @@ node('linux') {
     build job: 'Port-Pipeline', parameters: [
       string(name: 'PORT_GITHUB_REPO', value: 'https://github.com/zopencommunity/${name}port.git'),
       string(name: 'PORT_DESCRIPTION', value: '${_groovy_description}'),
-      string(name: 'BUILD_LINE', value: '${buildlineUpper}')
+      string(name: 'BUILD_LINE', value: '${buildlineUpper}'),
+      booleanParam(name: 'PUBLISH_PYTHON_WHEEL', value: ${publish_python_wheel})
     ]
   }
 }

--- a/bin/zopen-generate
+++ b/bin/zopen-generate
@@ -776,7 +776,7 @@ createCICD() {
   buildlineUpper=$(echo "${buildline}" | awk '{print toupper($0)}')
   _groovy_description=$(echo "$description" | sed "s/'/\"/g")
   publish_python_wheel=false
-  if [ "${build_system}" = "Python" ] && [ "${buildline}" = "stable" ]; then
+  if [ "${build_system}" = "Python" ]; then
     publish_python_wheel=true
   fi
   cat << EOT > "${name}port/cicd-${buildline}.groovy"

--- a/bin/zopen-publish
+++ b/bin/zopen-publish
@@ -62,7 +62,7 @@ printSyntax()
   echo ""
   echo "Examples:"
   echo "  zopen-publish -f -p install/mypackage.zos.pax.Z -m metadata.json -g DEV_mypackage_12345 -t <token>"
-  echo "  zopen-publish --whl dist/mypackage-1.0-py3-none-any.whl --pulp-url https://host/pulp/content/zopen/simple/"
+  echo "  zopen-publish --whl dist/mypackage-1.0-py3-none-any.whl --pulp-url https://repo.zopen.community/pypi/wheels/legacy/"
   echo "  zopen-publish -f -p install/mypackage.zos.pax.Z -m metadata.json -g TAG -t <token> --pulp"
 }
 
@@ -751,9 +751,9 @@ import email
 import hashlib
 import io
 import pathlib
+import re
 import shlex
 import sys
-import tempfile
 import zipfile
 
 src = pathlib.Path(sys.argv[1])
@@ -792,46 +792,54 @@ except Exception:
 if (major, minor) > (2, 3):
     upload_metadata_version = '2.1'
     upload_whl = compat_dir / src.name
-    with tempfile.TemporaryDirectory() as td_s:
-        td = pathlib.Path(td_s)
-        with zipfile.ZipFile(src) as zf:
-            zf.extractall(td)
+    with zipfile.ZipFile(src) as source:
+        source_infos = source.infolist()
+        files = {
+            info.filename: source.read(info.filename)
+            for info in source_infos
+            if not info.is_dir()
+        }
 
-        dist_info_dirs = list(td.glob('*.dist-info'))
-        if not dist_info_dirs:
-            raise SystemExit('Wheel does not contain a .dist-info directory')
-        dist_info = dist_info_dirs[0]
-        metadata_path = dist_info / 'METADATA'
-        text = metadata_path.read_text()
-        text = text.replace(f'Metadata-Version: {metadata_version}\n',
-                            f'Metadata-Version: {upload_metadata_version}\n', 1)
-        metadata_path.write_text(text)
+    record_name = metadata_name.rsplit('/', 1)[0] + '/RECORD'
+    if record_name not in files:
+        raise SystemExit('Wheel does not contain a .dist-info/RECORD file')
 
-        record_path = dist_info / 'RECORD'
-        rows = []
-        for path in sorted(p for p in td.rglob('*') if p.is_file()):
-            rel = path.relative_to(td).as_posix()
-            if rel.endswith('/RECORD'):
-                rows.append([rel, '', ''])
+    files[metadata_name] = metadata_text.replace(
+        f'Metadata-Version: {metadata_version}\n',
+        f'Metadata-Version: {upload_metadata_version}\n',
+        1,
+    ).encode('utf-8')
+
+    rows = []
+    for filename in sorted(files):
+        if filename == record_name:
+            rows.append([filename, '', ''])
+        else:
+            data = files[filename]
+            digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).decode().rstrip('=')
+            rows.append([filename, 'sha256=' + digest, str(len(data))])
+    record = io.StringIO(newline='')
+    csv.writer(record).writerows(rows)
+    files[record_name] = record.getvalue().encode('utf-8')
+
+    # Preserve each original ZipInfo, including timestamps and compression,
+    # so a retry creates a byte-for-byte identical compatibility wheel.
+    with zipfile.ZipFile(upload_whl, 'w') as target:
+        for info in source_infos:
+            if info.is_dir():
+                target.writestr(info, b'')
             else:
-                data = path.read_bytes()
-                digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).decode().rstrip('=')
-                rows.append([rel, 'sha256=' + digest, str(len(data))])
-        out = io.StringIO(newline='')
-        csv.writer(out).writerows(rows)
-        record_path.write_text(out.getvalue())
-
-        with zipfile.ZipFile(upload_whl, 'w', zipfile.ZIP_DEFLATED) as zf:
-            for path in sorted(p for p in td.rglob('*') if p.is_file()):
-                zf.write(path, path.relative_to(td).as_posix())
+                target.writestr(info, files[info.filename])
 
 sha256 = hashlib.sha256(upload_whl.read_bytes()).hexdigest()
+normalized_name = re.sub(r'[-_.]+', '-', name).lower()
 
 values = {
     'PULP_UPLOAD_WHL': str(upload_whl),
     'PULP_WHL_SHA256': sha256,
     'PULP_WHL_METADATA_VERSION': upload_metadata_version,
     'PULP_WHL_NAME': name,
+    'PULP_WHL_NORMALIZED_NAME': normalized_name,
     'PULP_WHL_VERSION': version,
     'PULP_WHL_SUMMARY': summary,
 }
@@ -842,71 +850,57 @@ with meta_env.open('w') as f:
 PY
 }
 
-publishPulpPythonRepository() {
+checkPulpWheelAlreadyPublished() {
   upload_url="$1"
+  wheel_filename="$2"
+  wheel_sha256="$3"
 
-  case "$upload_url" in
-    */pypi/*)
-      api_base="${upload_url%%/pypi/*}"
-      repo_base_path="${upload_url#*/pypi/}"
-      repo_base_path="${repo_base_path%%/*}"
-      ;;
-    *)
-      printVerbose "Unable to derive Pulp API URL from upload URL: ${upload_url}"
-      return 0
-      ;;
-  esac
+  simple_root="${upload_url%/legacy/}/simple"
+  package_url="${simple_root}/${PULP_WHL_NORMALIZED_NAME}/"
+  index_response=$(curl -sS \
+    -u "${PULP_USER}:${PULP_PASSWORD}" \
+    -H 'Accept: application/vnd.pypi.simple.v1+json' \
+    -w "\n%{http_code}" \
+    "${package_url}" 2>&1)
+  curl_rc=$?
 
-  encoded_base_path=$(printf '%s' "$repo_base_path" | jq -sRr @uri)
-  dist_response=$(curl -sS -u "${PULP_USER}:${PULP_PASSWORD}" \
-    "${api_base}/pulp/api/v3/distributions/python/pypi/?base_path=${encoded_base_path}" 2>&1)
-  repo_href=$(echo "$dist_response" | jq -r '.results[0].repository // empty' 2>/dev/null)
+  if [ ${curl_rc} -ne 0 ]; then
+    printSoftError "Unable to check existing Pulp package at ${package_url}: ${index_response}"
+    return 3
+  fi
 
-  if [ -z "$repo_href" ]; then
-    printVerbose "Unable to find Pulp Python repository for base path: ${repo_base_path}"
+  index_http_code=$(echo "${index_response}" | tail -1)
+  index_body=$(echo "${index_response}" | sed '$d')
+
+  if [ "${index_http_code}" = "404" ]; then
+    return 1
+  fi
+  if [ "${index_http_code}" != "200" ]; then
+    printSoftError "Pulp package lookup failed with HTTP ${index_http_code}: ${index_body}"
+    return 3
+  fi
+
+  if ! echo "${index_body}" | jq -e '.files | type == "array"' >/dev/null 2>&1; then
+    printSoftError "Pulp package lookup returned invalid PEP 691 JSON from ${package_url}"
+    return 3
+  fi
+
+  existing_sha256=$(echo "${index_body}" | jq -r \
+    --arg filename "${wheel_filename}" \
+    '.files[]? | select(.filename == $filename) | .hashes.sha256 // empty' \
+    2>/dev/null | head -1)
+
+  if [ -z "${existing_sha256}" ]; then
+    return 1
+  fi
+  if [ "${existing_sha256}" = "${wheel_sha256}" ]; then
     return 0
   fi
 
-  printVerbose "Creating Pulp Python publication for ${repo_base_path} (${repo_href})"
-  pub_payload=$(jq -cn --arg repository "$repo_href" '{repository:$repository}')
-  pub_response=$(curl -sS -u "${PULP_USER}:${PULP_PASSWORD}" \
-    -H 'Content-Type: application/json' \
-    -X POST "${api_base}/pulp/api/v3/publications/python/pypi/" \
-    -d "$pub_payload" 2>&1)
-  pub_task=$(echo "$pub_response" | jq -r '.task // empty' 2>/dev/null)
-
-  if [ -z "$pub_task" ]; then
-    printVerbose "No Pulp publication task was returned: ${pub_response}"
-    return 0
-  fi
-
-  retries=0
-  while [ $retries -lt 30 ]; do
-    pub_task_response=$(curl -sS -u "${PULP_USER}:${PULP_PASSWORD}" "${api_base}${pub_task}" 2>&1)
-    pub_task_state=$(echo "$pub_task_response" | jq -r '.state // empty' 2>/dev/null)
-
-    case "$pub_task_state" in
-      completed)
-        printVerbose "Pulp Python publication completed for ${repo_base_path}."
-        return 0
-        ;;
-      failed)
-        pub_task_error=$(echo "$pub_task_response" | jq -r '.error.description // empty' 2>/dev/null)
-        printSoftError "Pulp publication task failed: ${pub_task_error}"
-        return 1
-        ;;
-      canceled)
-        printSoftError "Pulp publication task was canceled."
-        return 1
-        ;;
-    esac
-
-    retries=$((retries + 1))
-    sleep 2
-  done
-
-  printSoftError "Pulp publication task did not complete within 60 seconds."
-  return 1
+  printSoftError "Immutable wheel conflict for ${wheel_filename}:"
+  printSoftError "Pulp SHA256: ${existing_sha256}"
+  printSoftError "Local SHA256: ${wheel_sha256}"
+  return 2
 }
 
 publishToPulp() {
@@ -927,6 +921,25 @@ publishToPulp() {
     printInfo "Created Pulp-compatible wheel metadata copy: ${PULP_UPLOAD_WHL}"
   fi
 
+  checkPulpWheelAlreadyPublished \
+    "${pulp_upload_url}" \
+    "${whl_basename}" \
+    "${PULP_WHL_SHA256}"
+  existing_status=$?
+  case "${existing_status}" in
+    0)
+      printInfo "Wheel ${whl_basename} is already published with the same SHA256; nothing to do."
+      rm -rf "$tmp_dir"
+      return 0
+      ;;
+    1)
+      ;;
+    2|3)
+      rm -rf "$tmp_dir"
+      return 1
+      ;;
+  esac
+
   printInfo "Uploading ${whl_basename} to ${pulp_upload_url}"
 
   UPLOAD_RESPONSE=$(curl -sS -w "\n%{http_code}" \
@@ -945,7 +958,20 @@ publishToPulp() {
   http_code=$(echo "$UPLOAD_RESPONSE" | tail -1)
   response_body=$(echo "$UPLOAD_RESPONSE" | sed '$d')
 
-  if [ "$http_code" != "200" ] && [ "$http_code" != "201" ]; then
+  if [ "$http_code" != "200" ] && [ "$http_code" != "201" ] && [ "$http_code" != "202" ]; then
+    # Another publisher may have won the race between our preflight check
+    # and upload. Re-check before reporting failure.
+    checkPulpWheelAlreadyPublished \
+      "${pulp_upload_url}" \
+      "${whl_basename}" \
+      "${PULP_WHL_SHA256}"
+    post_upload_status=$?
+    if [ "${post_upload_status}" = "0" ]; then
+      printInfo "Wheel ${whl_basename} was published concurrently with the same SHA256; treating the upload as successful."
+      rm -rf "$tmp_dir"
+      return 0
+    fi
+
     printSoftError "Pulp upload failed with HTTP ${http_code}"
     printSoftError "Response: ${response_body}"
     rm -rf "$tmp_dir"
@@ -976,10 +1002,6 @@ publishToPulp() {
 
       case "$task_state" in
         completed)
-          if ! publishPulpPythonRepository "$pulp_upload_url"; then
-            rm -rf "$tmp_dir"
-            return 1
-          fi
           printInfo "Wheel ${whl_basename} published to Pulp successfully."
           rm -rf "$tmp_dir"
           return 0
@@ -1004,11 +1026,6 @@ publishToPulp() {
     done
 
     printSoftError "Pulp task did not complete within 60 seconds."
-    rm -rf "$tmp_dir"
-    return 1
-  fi
-
-  if ! publishPulpPythonRepository "$pulp_upload_url"; then
     rm -rf "$tmp_dir"
     return 1
   fi

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -103,4 +103,4 @@ This directory contains the Jenkins Pipeline scripts (Groovy) used to orchestrat
   * `PULP_URL`: Optional upload endpoint override.
   * `PULP_USER_CREDENTIAL` and `PULP_PASSWORD_CREDENTIAL`: Optional Jenkins credential ID overrides.
 
-Selecting `Python` as the build system in `zopen-generate` writes `PUBLISH_PYTHON_WHEEL=true` into `cicd-stable.groovy`. Development and non-Python CI/CD files use `false`, so they still build and test normally without publishing into the public wheel index.
+Selecting `Python` as the build system in `zopen-generate` writes `PUBLISH_PYTHON_WHEEL=true` into both `cicd-stable.groovy` and `cicd-dev.groovy`. Non-Python CI/CD files use `false`, so C and C++ ports continue through their existing publication paths without publishing into the Python wheel index.

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -1,6 +1,6 @@
 # Jenkins CI/CD Pipelines
 
-This directory contains the Jenkins Pipeline scripts (Groovy) used to orchestrate the build, packaging, testing, and publication of both **Port packages** (pax.Z format) and **RPM packages** in the zopencommunity environment.
+This directory contains the Jenkins Pipeline scripts (Groovy) used to orchestrate the build, packaging, testing, and publication of **Port packages** (pax.Z format), **RPM packages**, and opt-in **Python wheels** in the zopencommunity environment.
 
 ---
 
@@ -14,23 +14,26 @@ This directory contains the Jenkins Pipeline scripts (Groovy) used to orchestrat
      - **Port-Publish**: Publishes the `.pax.Z` packages as a GitHub release on the port's repository.
      - **UpdateReleaseAPIs**: Updates the release metadata API definitions.
      - **RPM-Publish**: Triggers `RPM-Publish` to upload generated RPMs to Pulp.
+     - **Python-Publish**: For generated Python ports, uploads wheel artifacts to the zopen Pulp Python index.
 * **Key Parameters**:
   * `PORT_GITHUB_REPO`: Upstream GitHub repository URL of the port (e.g. `makeport`).
   * `PORT_BRANCH`: Git branch to build (default: `main`).
   * `BUILD_LINE`: Release line to build against (default: `stable`).
   * `NO_PROMOTE`: Boolean flag to skip the package publication step.
+  * `PUBLISH_PYTHON_WHEEL`: Enables wheel staging and publication. `zopen-generate` sets this for Python build-system ports.
 
 ### 2. Port Build Pipeline (`build.groovy`)
 * **Purpose**: Compiles, builds, and runs test suites for the target port project on the z/OS host machine.
 * **Flow**:
   1. **Build Project**: Clones the port repository and runs `zopen-build` to compile the port.
-  2. **Artifact Packaging**: Generates both `.pax.Z` and `.rpm` files and signs them using GPG keys.
+  2. **Artifact Packaging**: Generates `.pax.Z` and `.rpm` files and, for Python ports, stages preserved wheels under `wheels/`.
   3. **Archive**: Archives build artifacts (metadata, packages, logs) inside Jenkins.
 * **Key Parameters**:
   * `PORT_GITHUB_REPO`: Upstream GitHub repository URL of the port.
   * `PORT_BRANCH`: Git branch to build (default: `main`).
   * `FORCE_CLANG`: Enforces compiling the project with Clang rather than `xlclang`.
   * `GENERATE_PAX_RPM`: Boolean flag to enable/disable package generation.
+  * `PUBLISH_PYTHON_WHEEL`: Requires and archives wheels produced by the native Python build path.
 
 ### 3. Port Publish Pipeline (`publish.groovy`)
 * **Purpose**: Takes `.pax.Z` build artifacts and publishes them to public GitHub releases.
@@ -80,3 +83,24 @@ This directory contains the Jenkins Pipeline scripts (Groovy) used to orchestrat
   3. **GPG Config**: Configures the repository signature verification parameters (`gpgcheck: 1`) and automatically generates the `.repo` client configuration file.
 * **Key Parameters**:
   * `PULP_REPO`: Name of the target RPM repository (default: `zopen`).
+
+---
+
+## Python Wheel Pipeline
+
+### Python Publish Pipeline (`publish_python.groovy`)
+
+* **Purpose**: Fetches wheels from an opted-in `Port-Build`, publishes them to the `wheels` Pulp Python repository, and verifies the public index.
+* **Flow**:
+  1. Copies `wheels/**/*.whl` from the selected `Port-Build`.
+  2. Publishes every wheel through `https://repo.zopen.community/pypi/wheels/legacy/`.
+  3. Installs pure Python wheels from the public simple index in a clean virtual environment.
+  4. For platform-specific wheels, verifies that the exact filename is present in the public package index; installation must be tested on a compatible node.
+  5. Treats an existing filename with the same SHA-256 as a successful retry and rejects the same filename with different content.
+* **Key Parameters**:
+  * `PROMOTED_JOB_NAME`: Required source build job, normally `Port-Build`.
+  * `BUILD_SELECTOR`: Build number or Copy Artifact selector.
+  * `PULP_URL`: Optional upload endpoint override.
+  * `PULP_USER_CREDENTIAL` and `PULP_PASSWORD_CREDENTIAL`: Optional Jenkins credential ID overrides.
+
+Selecting `Python` as the build system in `zopen-generate` writes `PUBLISH_PYTHON_WHEEL=true` into `cicd-stable.groovy`. Development and non-Python CI/CD files use `false`, so they still build and test normally without publishing into the public wheel index.

--- a/cicd/build.groovy
+++ b/cicd/build.groovy
@@ -9,9 +9,11 @@
 //   - BUILD_LINE: dev or stable
 //   - FORCE_CLANG : Build using clang
 //   - GENERATE_PAX_RPM : (default: true) Generate pax and RPM packages. Set to false to skip -gr -sp options
+//   - PUBLISH_PYTHON_WHEEL : Stage Python wheels produced by zopen-build for publication
 //   - NODE_LABEL: Label of the Jenkins node to run on (default: zos)
 // Output:
 //   - pax.Z artifact is published as a Jenkins artifact
+//   - Python wheels are staged under wheels/ when PUBLISH_PYTHON_WHEEL is true
 //   - package is copied to /jenkins/build on z/OS zot system
 
 def port_github_repo = params.PORT_GITHUB_REPO ?: ""
@@ -20,6 +22,7 @@ def port_source_url  = params.PORT_SOURCE_URL  ?: ""
 def build_line       = params.BUILD_LINE       ?: ""
 def force_clang      = params.FORCE_CLANG != null ? params.FORCE_CLANG : false
 def generate_pax_rpm = params.GENERATE_PAX_RPM != null ? params.GENERATE_PAX_RPM : true
+def publish_python_wheel = params.PUBLISH_PYTHON_WHEEL != null ? params.PUBLISH_PYTHON_WHEEL : false
 def skip_test        = params.SKIP_TEST != null ? params.SKIP_TEST : false
 def node_label       = params.node ?: (params.NODE_LABEL ?: "zos")
 
@@ -73,6 +76,7 @@ node(node_label) {
           "PORT_SOURCE_URL=${port_source_url}",
           "EXTRA_OPTIONS=${extraOptions}",
           "PAX_RPM_OPTIONS=${paxRpmOptions}",
+          "PUBLISH_PYTHON_WHEEL=${publish_python_wheel}",
           "TEST_OPTION=${testOption}"
         ]) {
           sh '''bash -e -s << \'BASH\'
@@ -107,6 +111,24 @@ node(node_label) {
             # Run build using the workspace version of zopen-build to test PR changes
             zopen-build -v -b release -u ${TEST_OPTION} ${PAX_RPM_OPTIONS} --no-set-active ${EXTRA_OPTIONS}
 
+            # Python builds preserve their wheel under install/**/dist. Stage
+            # the final artifact separately so the publisher does not need to
+            # know anything about the port's source layout.
+            if [ "${PUBLISH_PYTHON_WHEEL}" = "true" ]; then
+              mkdir -p "${WORKSPACE}/wheels"
+              wheel_count=0
+              while IFS= read -r wheel; do
+                cp "$wheel" "${WORKSPACE}/wheels/"
+                wheel_count=$((wheel_count + 1))
+              done < <(find install -type f -name '*.whl' 2>/dev/null)
+
+              if [ "$wheel_count" -eq 0 ]; then
+                echo "ERROR: PUBLISH_PYTHON_WHEEL is enabled, but zopen-build produced no wheel under install/." >&2
+                exit 1
+              fi
+              echo "Staged ${wheel_count} Python wheel(s) for publication."
+            fi
+
             # Clean using the workspace version of zopen-clean
             zopen-clean -c -v
 
@@ -120,7 +142,7 @@ BASH'''
       }
     } finally {
       try {
-        archiveArtifacts artifacts: '**/*.pax.Z,**/*.pax.Z.asc,**/*.rpm,**/metadata.json,**/*_config.log,**/*_build.log,**/*_check.log,**/*_install.log, **/test.status, **/*_check_failures.log, **/.builddeps, **/.version, **/.runtimedeps',
+        archiveArtifacts artifacts: '**/*.pax.Z,**/*.pax.Z.asc,**/*.rpm,wheels/**/*.whl,**/metadata.json,**/*_config.log,**/*_build.log,**/*_check.log,**/*_install.log, **/test.status, **/*_check_failures.log, **/.builddeps, **/.version, **/.runtimedeps',
                          allowEmptyArchive: true,
                          fingerprint: true
       } finally {

--- a/cicd/pipeline.jenkins
+++ b/cicd/pipeline.jenkins
@@ -5,6 +5,7 @@
 //   BUILD_LINE: dev or stable line to build against (default: stable)
 //   FORCE_CLANG : Boolean to enforce building with Clang vs xlclang
 //   GENERATE_PAX_RPM : Boolean to generate pax/RPM artifacts (default: true)
+//   PUBLISH_PYTHON_WHEEL : Boolean to publish wheels produced by Python ports
 //   NO_PROMOTE : Boolean, if true, avoid promotion
 //   NODE_LABEL : A label for the node to build on, default is "zos"
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
@@ -19,6 +20,7 @@ def branch = params.get("PORT_BRANCH")
 def description = params.get("PORT_DESCRIPTION")
 def build_line = params.get("BUILD_LINE")  // DEV or STABLE
 def node_label = params.get("NODE_LABEL")  
+def publish_python_wheel = params.PUBLISH_PYTHON_WHEEL != null ? params.PUBLISH_PYTHON_WHEEL : false
 
 RunWrapper buildResult;
 RunWrapper promoteResult;
@@ -33,6 +35,7 @@ node('linux')
                    string(name: 'node', value: "${node_label}"),
                    booleanParam(name: 'FORCE_CLANG', value: params.FORCE_CLANG != null ? params.FORCE_CLANG : false),
                    booleanParam(name: 'GENERATE_PAX_RPM', value: true),
+                   booleanParam(name: 'PUBLISH_PYTHON_WHEEL', value: publish_python_wheel),
                    booleanParam(name: 'SKIP_TEST', value: params.SKIP_TEST != null ? params.SKIP_TEST : false),
                    string(name: 'BUILD_LINE', value: "${build_line}"),
                    ]
@@ -91,6 +94,21 @@ node('linux')
           def rpmResult = rpmPromoteResult.getResult()
           if(rpmResult != "SUCCESS"){
             handleError("RPM Promote stage failed. View details in ${rpmPromoteResult.absoluteUrl}", repo, getLogFromRunWrapper(rpmPromoteResult, 50));
+          }
+        }
+      }
+    },
+    'Publish Python': {
+      stage('Python-Publish') {
+        if(!params.NO_PROMOTE && publish_python_wheel &&
+           !(params.SKIP_PYTHON_PUBLISH != null ? params.SKIP_PYTHON_PUBLISH : false)) {
+          def pythonPromoteResult = build job: 'Python-Publish', propagate: false, parameters:
+             [string(name: 'BUILD_SELECTOR', value: "<SpecificBuildSelector plugin=\"copyartifact@1.46.2\">  <buildNumber>${buildResult.number.toString()}</buildNumber></SpecificBuildSelector>"),
+              string(name: 'PROMOTED_JOB_NAME', value: 'Port-Build')
+             ]
+          def pythonResult = pythonPromoteResult.getResult()
+          if(pythonResult != "SUCCESS"){
+            handleError("Python wheel publish stage failed. View details in ${pythonPromoteResult.absoluteUrl}", repo, getLogFromRunWrapper(pythonPromoteResult, 50));
           }
         }
       }

--- a/cicd/publish_python.groovy
+++ b/cicd/publish_python.groovy
@@ -1,0 +1,154 @@
+// Python wheel publish job.
+//
+// Inputs:
+//   BUILD_SELECTOR          : Jenkins build selector XML, build number, or lastSuccessful
+//   PROMOTED_JOB_NAME       : Required job from which to copy wheel artifacts
+//   PULP_URL                : Optional upload URL override
+//   PULP_USER_CREDENTIAL    : Optional Jenkins username credential ID
+//   PULP_PASSWORD_CREDENTIAL: Optional Jenkins password credential ID
+
+def build_selector       = params.BUILD_SELECTOR ?: ""
+def promoted_job_name    = params.PROMOTED_JOB_NAME
+def pulp_url             = params.PULP_URL ?: "https://repo.zopen.community/pypi/wheels/legacy/"
+def pulp_user_credential = params.PULP_USER_CREDENTIAL ?: "PULP_USERNAME"
+def pulp_pass_credential = params.PULP_PASSWORD_CREDENTIAL ?: "PULP_PASSWORD"
+
+if (!promoted_job_name) {
+  error "Required parameter 'PROMOTED_JOB_NAME' is missing or empty."
+}
+
+node('linux') {
+  try {
+    stage('Setup') {
+      deleteDir()
+      checkout scm
+
+      def selectorObj
+      if (build_selector) {
+        if (build_selector.contains('SpecificBuildSelector')) {
+          def matcher = (build_selector =~ /<buildNumber>(.*?)<\/buildNumber>/)
+          selectorObj = matcher.find() ? specific(matcher.group(1)) : lastSuccessful()
+        } else if (build_selector.contains('StatusBuildSelector')) {
+          selectorObj = lastSuccessful()
+        } else if (build_selector == 'latest' || build_selector == 'lastSuccessful') {
+          selectorObj = lastSuccessful()
+        } else {
+          selectorObj = specific(build_selector)
+        }
+      } else {
+        selectorObj = lastSuccessful()
+      }
+
+      copyArtifacts filter: 'wheels/**/*.whl',
+                    fingerprintArtifacts: true,
+                    projectName: promoted_job_name,
+                    selector: selectorObj
+
+      def wheelCount = sh(
+        script: 'find wheels -type f -name "*.whl" | wc -l',
+        returnStdout: true
+      ).trim().toInteger()
+
+      if (wheelCount == 0) {
+        error "No Python wheels were found in the copied build artifacts."
+      }
+      echo "Found ${wheelCount} Python wheel(s) to publish."
+    }
+
+    stage('Pulp Upload') {
+      withCredentials([
+        string(credentialsId: pulp_user_credential, variable: 'PULP_USER'),
+        string(credentialsId: pulp_pass_credential, variable: 'PULP_PASSWORD')
+      ]) {
+        withEnv(["PULP_URL=${pulp_url}"]) {
+          sh '''#!/bin/bash
+set -euo pipefail
+
+if [ -f /jenkins/.env ]; then
+  . /jenkins/.env
+fi
+
+publisher="${WORKSPACE}/bin/zopen-publish"
+if [ ! -x "$publisher" ]; then
+  echo "ERROR: zopen-publish is not available at $publisher" >&2
+  exit 1
+fi
+
+wheel_files=()
+while IFS= read -r -d '' wheel; do
+  wheel_files+=("$wheel")
+done < <(find wheels -type f -name '*.whl' -print0)
+
+for wheel in "${wheel_files[@]}"; do
+  ZOPEN_DONT_PROCESS_CONFIG=1 \
+    "$publisher" --whl "$wheel" --pulp-url "$PULP_URL"
+done
+'''
+        }
+      }
+    }
+
+    stage('Public Index Verification') {
+      withEnv(["PULP_URL=${pulp_url}"]) {
+        sh '''#!/bin/bash
+set -euo pipefail
+
+index_url="${PULP_URL%/legacy/}/simple/"
+smoke_root="${WORKSPACE}/wheel-smoke"
+mkdir -p "$smoke_root"
+
+wheel_number=0
+while IFS= read -r -d '' wheel; do
+  wheel_number=$((wheel_number + 1))
+  wheel_name=$(basename "$wheel")
+
+  IFS=$'\t' read -r package_name package_version normalized_name < <(
+    python3 - "$wheel" <<'PY'
+import email
+import re
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    metadata_files = [
+        name for name in archive.namelist()
+        if name.endswith(".dist-info/METADATA")
+    ]
+    if len(metadata_files) != 1:
+        raise SystemExit("Wheel must contain exactly one .dist-info/METADATA file")
+    metadata = email.message_from_bytes(archive.read(metadata_files[0]))
+
+name = metadata.get("Name")
+version = metadata.get("Version")
+if not name or not version:
+    raise SystemExit("Wheel metadata is missing Name or Version")
+
+normalized = re.sub(r"[-_.]+", "-", name).lower()
+print(f"{name}\t{version}\t{normalized}")
+PY
+  )
+
+  package_page="${index_url}${normalized_name}/"
+  echo "Verifying ${package_name}==${package_version} at ${package_page}"
+
+  if [[ "$wheel_name" == *-py3-none-any.whl ]]; then
+    venv="${smoke_root}/${wheel_number}"
+    python3 -m venv "$venv"
+    "$venv/bin/pip" install \
+      --no-cache-dir \
+      --no-deps \
+      --index-url "$index_url" \
+      "${package_name}==${package_version}"
+    "$venv/bin/python" -m pip show "$package_name" >/dev/null
+  else
+    curl --fail --silent --show-error "$package_page" | grep -F "$wheel_name" >/dev/null
+    echo "Platform-specific wheel is present in the public index; install verification is deferred to a compatible node."
+  fi
+done < <(find wheels -type f -name '*.whl' -print0)
+'''
+      }
+    }
+  } finally {
+    deleteDir()
+  }
+}


### PR DESCRIPTION
## Summary

- generate `PUBLISH_PYTHON_WHEEL=true` for both dev and stable Python ports while keeping non-Python ports disabled
- stage wheels produced under `install/**`, archive them independently from pax/RPM artifacts, and route opted-in builds to a dedicated `Python-Publish` Jenkins job
- publish to the `wheels` Pulp Python repository and verify pure-Python wheels with pip against the public index
- make wheel retries idempotent by comparing exact filenames and SHA-256 hashes before upload, rejecting conflicting content, and rechecking after concurrent uploads
- make wheel metadata compatibility rewrites deterministic and RECORD-correct

## Validation

- `sh -n bin/zopen-generate bin/zopen-publish`
- syntax-checked the embedded Bash blocks in `cicd/publish_python.groovy`
- `git diff --check`
- generator smoke tests: Python stable and dev enabled; CMake stable and dev disabled
- mocked retry cases: identical retry skipped, conflicting retry rejected, malformed index rejected, absent wheel uploaded, and concurrent identical upload accepted
- deterministic compatibility rewrite test produced identical SHA-256 output across repeated runs
- live read-only retry check against the existing public test wheel correctly skipped upload

## Rollout notes

- create/configure a Jenkins `Python-Publish` job backed by `cicd/publish_python.groovy`
- provide Jenkins string credentials `PULP_USERNAME` and `PULP_PASSWORD`, or override their credential IDs through job parameters
- correct the Pulp `CONTENT_ORIGIN` public URL separately before production rollout; this is server configuration and is intentionally outside this repository change
- platform-specific wheel installation still requires validation on a compatible node; this pipeline verifies exact public-index presence for those wheels
