### PR TITLE
Build, test and publish a wheel per Python interpreter

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -360,12 +360,40 @@ _zopen_python_primary_version() {
   done
 }
 
+# Resolve a declared version to an interpreter. The versioned name wins, but
+# fall back to python3/python when one of those reports the version asked for:
+# a runtime may install only an unversioned binary, and refusing to pin in that
+# case would make ZOPEN_PYTHON_VERSIONS unusable on exactly the systems where
+# declaring the target version is most useful.
 _zopen_python_interpreter_path() {
   if [ "$1" = "default" ]; then
-    command -v python 2> /dev/null
-  else
-    command -v "python$1" 2> /dev/null
+    for _pi_name in python python3; do
+      _pi_path=$(command -v "${_pi_name}" 2> /dev/null)
+      if [ -n "${_pi_path}" ]; then
+        echo "${_pi_path}"
+        return 0
+      fi
+    done
+    return 1
   fi
+
+  _pi_path=$(command -v "python$1" 2> /dev/null)
+  if [ -n "${_pi_path}" ]; then
+    echo "${_pi_path}"
+    return 0
+  fi
+
+  for _pi_name in python3 python; do
+    _pi_path=$(command -v "${_pi_name}" 2> /dev/null)
+    [ -n "${_pi_path}" ] || continue
+    _pi_actual=$("${_pi_path}" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2> /dev/null)
+    if [ "${_pi_actual}" = "$1" ]; then
+      echo "${_pi_path}"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 # Verify every declared interpreter exists and reports the version it claims,
@@ -392,6 +420,11 @@ _zopen_python_verify_interpreters() {
   done
 
   if [ -n "${_py_missing}" ] || [ -n "${_py_mismatch}" ]; then
+    if [ -z "${ZOPEN_PYTHON_VERSIONS}" ]; then
+      # Nothing was declared, so the only failure possible is having no
+      # interpreter at all; naming the "default" sentinel would just confuse.
+      printError "No 'python' or 'python3' found on PATH"
+    fi
     [ -n "${_py_missing}" ] && printSoftError "Declared Python interpreter(s) not found:${_py_missing}"
     [ -n "${_py_mismatch}" ] && printSoftError "Python interpreter(s) report a different version:${_py_mismatch}"
     printSoftError "ZOPEN_PYTHON_VERSIONS=\"${ZOPEN_PYTHON_VERSIONS}\""

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -52,6 +52,17 @@ Required:
 Optional:
   ZOPEN_SOURCE_URL      If set, use this as ZOPEN_URL before checking
                         ZOPEN_DEV_URL or ZOPEN_STABLE_URL.
+  ZOPEN_PYTHON_VERSIONS Python build system only. Space-delimited Python minor
+                        versions to build, test and publish a wheel for, most
+                        significant first, e.g. '3.12 3.13'. The first is the
+                        primary and is what gets installed into the package;
+                        every version's wheel is published. Each interpreter
+                        must be on PATH as python<version> or the build fails
+                        before compiling. Defaults to the active python.
+  ZOPEN_PYTHON_WHEEL_RETAG
+                        Python build system only. Set to 'false' to keep the
+                        default platform tag on compiled wheels instead of
+                        retagging them to cp3XY-none-any (defaults to 'true').
   ZOPEN_EXTRA_CFLAGS    C compiler flags to append to CFLAGS (defaults to '').
   ZOPEN_EXTRA_CPPFLAGS  C,C++ pre-processor flags to append to CPPFLAGS.
                         (defaults to '')
@@ -318,13 +329,118 @@ setDefaults()
 
 # --- Built-in Python build system functions ---
 
-_zopen_python_ensure_venv() {
-  if [ ! -f ".venv/bin/activate" ]; then
-    printInfo "Creating Python virtual environment..."
-    python -m venv .venv
+# --- Multi-interpreter Python support ---
+#
+# A compiled extension is bound to one CPython ABI, so covering several
+# interpreters means building, testing and publishing one wheel per version.
+# ZOPEN_PYTHON_VERSIONS declares which, most significant first:
+#
+#   export ZOPEN_PYTHON_VERSIONS="3.12 3.13"
+#
+# The first entry is the primary. Its build is what gets installed into the
+# pax, because an installed tree can only carry one interpreter's extension;
+# every built wheel is published regardless.
+#
+# Left unset, everything runs against the active `python` exactly as before.
+
+# Echo the declared versions, or the sentinel "default" meaning "whatever
+# python is on PATH" -- which keeps single-interpreter ports unchanged.
+_zopen_python_versions() {
+  if [ -z "${ZOPEN_PYTHON_VERSIONS}" ]; then
+    echo "default"
+  else
+    echo "${ZOPEN_PYTHON_VERSIONS}"
   fi
-  . .venv/bin/activate
+}
+
+_zopen_python_primary_version() {
+  for _pv in $(_zopen_python_versions); do
+    echo "${_pv}"
+    return 0
+  done
+}
+
+_zopen_python_interpreter_path() {
+  if [ "$1" = "default" ]; then
+    command -v python 2> /dev/null
+  else
+    command -v "python$1" 2> /dev/null
+  fi
+}
+
+# Verify every declared interpreter exists and reports the version it claims,
+# before anything is compiled. Without this a node missing an interpreter would
+# quietly publish fewer wheels than intended, and nobody would find out until an
+# install failed with "no matching distribution".
+_zopen_python_verify_interpreters() {
+  _py_missing=""
+  _py_mismatch=""
+
+  for _pv in $(_zopen_python_versions); do
+    _pv_path=$(_zopen_python_interpreter_path "${_pv}")
+    if [ -z "${_pv_path}" ]; then
+      _py_missing="${_py_missing} ${_pv}"
+      continue
+    fi
+
+    [ "${_pv}" = "default" ] && continue
+
+    _pv_actual=$("${_pv_path}" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2> /dev/null)
+    if [ "${_pv_actual}" != "${_pv}" ]; then
+      _py_mismatch="${_py_mismatch} ${_pv}(reports ${_pv_actual:-unknown})"
+    fi
+  done
+
+  if [ -n "${_py_missing}" ] || [ -n "${_py_mismatch}" ]; then
+    [ -n "${_py_missing}" ] && printSoftError "Declared Python interpreter(s) not found:${_py_missing}"
+    [ -n "${_py_mismatch}" ] && printSoftError "Python interpreter(s) report a different version:${_py_mismatch}"
+    printSoftError "ZOPEN_PYTHON_VERSIONS=\"${ZOPEN_PYTHON_VERSIONS}\""
+    printError "Cannot build for every declared Python version"
+  fi
+
+  return 0
+}
+
+# The primary keeps the plain .venv name so ports that reference it directly,
+# and the existing single-interpreter layout, are unaffected.
+_zopen_python_venv_dir() {
+  if [ "$1" = "default" ] || [ "$1" = "$(_zopen_python_primary_version)" ]; then
+    echo ".venv"
+  else
+    echo ".venv-$1"
+  fi
+}
+
+_zopen_python_ensure_venv_for() {
+  _pv_venv=$(_zopen_python_venv_dir "$1")
+  if [ ! -f "${_pv_venv}/bin/activate" ]; then
+    printInfo "Creating Python virtual environment for ${1} in ${_pv_venv}..."
+    "$(_zopen_python_interpreter_path "$1")" -m venv "${_pv_venv}" || return 1
+  fi
+  . "${_pv_venv}/bin/activate" || return 1
   pip install setuptools build installer wheel
+}
+
+# Retained for ports that call it directly.
+_zopen_python_ensure_venv() {
+  _zopen_python_ensure_venv_for "$(_zopen_python_primary_version)"
+}
+
+# Interpreter tag (cp312) of the currently active python.
+_zopen_python_active_tag() {
+  python -c 'import sys; print("cp%d%d" % sys.version_info[:2])' 2> /dev/null
+}
+
+# The wheel matching an interpreter tag, falling back to a pure Python wheel,
+# which is valid for every interpreter.
+_zopen_python_wheel_for_tag() {
+  for _pw in dist/*-"$1"-none-any.whl; do
+    [ -f "${_pw}" ] && { echo "${_pw}"; return 0; }
+  done
+  for _pw in dist/*-py3-none-any.whl; do
+    [ -f "${_pw}" ] && { echo "${_pw}"; return 0; }
+  done
+  return 1
 }
 
 # Retag a compiled wheel so it is not pinned to the z/OS release and machine
@@ -354,7 +470,16 @@ _zopen_python_retag_wheel() {
     _whl_base=$(basename "${_whl}" .whl)
     _whl_plat=$(echo "${_whl_base}" | awk -F- '{print $NF}')
     if [ "${_whl_plat}" = "any" ]; then
-      printVerbose "$(basename "${_whl}") is platform independent; leaving its tags unchanged"
+      # Distinguish a genuinely portable wheel from one an earlier interpreter's
+      # pass already retagged, which is still sitting in dist/.
+      case "$(echo "${_whl_base}" | awk -F- '{print $(NF-2)}')" in
+        cp*)
+          printVerbose "$(basename "${_whl}") was already retagged; skipping"
+          ;;
+        *)
+          printVerbose "$(basename "${_whl}") is platform independent; leaving its tags unchanged"
+          ;;
+      esac
       continue
     fi
 
@@ -407,7 +532,7 @@ _zopen_python_source_date_epoch() {
 }
 
 _zopen_python_build() {
-  _zopen_python_ensure_venv
+  _zopen_python_verify_interpreters || return 1
   rm -rf dist
 
   # Respect an externally supplied value so a caller can pin it explicitly.
@@ -421,38 +546,108 @@ _zopen_python_build() {
     fi
   fi
 
-  python -m build --wheel
-  _zopen_python_build_rc=$?
+  _zopen_python_build_rc=0
+  _py_pure=false
 
-  # Retag before anything downstream sees the wheel, so the check and install
-  # phases and the published artifact all refer to the same file.
-  if [ ${_zopen_python_build_rc} -eq 0 ]; then
-    _zopen_python_retag_wheel
+  for _pv in $(_zopen_python_versions); do
+    # A pure Python wheel is identical whatever built it, and every interpreter
+    # produces the same filename, so rebuilding would only overwrite it. The
+    # venv is still created below, because the check phase needs one per
+    # interpreter even when the wheel is shared.
+    if ${_py_pure}; then
+      printInfo "Wheel is platform independent; skipping rebuild for ${_pv}"
+      _zopen_python_ensure_venv_for "${_pv}" || { _zopen_python_build_rc=1; break; }
+      deactivate
+      continue
+    fi
+
+    printHeader "Building wheel with Python ${_pv}"
+    _zopen_python_ensure_venv_for "${_pv}" || { _zopen_python_build_rc=1; break; }
+
+    python -m build --wheel
     _zopen_python_build_rc=$?
-  fi
 
-  deactivate
+    # Retag before anything downstream sees the wheel, so the check and install
+    # phases and the published artifact all refer to the same file.
+    if [ ${_zopen_python_build_rc} -eq 0 ]; then
+      _zopen_python_retag_wheel
+      _zopen_python_build_rc=$?
+    fi
+
+    if [ ${_zopen_python_build_rc} -eq 0 ]; then
+      for _pw in dist/*-py3-none-any.whl; do
+        [ -f "${_pw}" ] && _py_pure=true
+      done
+    fi
+
+    deactivate
+    [ ${_zopen_python_build_rc} -eq 0 ] || break
+  done
+
   return ${_zopen_python_build_rc}
 }
 
 _zopen_python_check() {
-  . .venv/bin/activate
-  pip install pytest
-  # Install the built wheel so C extensions (.so files) are available
-  # Use --force-reinstall to ensure the newly built wheel is used
-  pip install --force-reinstall --no-deps dist/*.whl
-  python -m pytest -v
-  _zopen_python_check_rc=$?
-  deactivate
+  _zopen_python_check_rc=0
+
+  for _pv in $(_zopen_python_versions); do
+    _pv_venv=$(_zopen_python_venv_dir "${_pv}")
+    if [ ! -f "${_pv_venv}/bin/activate" ]; then
+      printSoftError "No virtual environment at ${_pv_venv} for Python ${_pv}"
+      _zopen_python_check_rc=1
+      break
+    fi
+
+    printHeader "Running tests with Python ${_pv}"
+    . "${_pv_venv}/bin/activate"
+    pip install pytest
+
+    # Install the wheel built for *this* interpreter. Globbing dist/*.whl would
+    # hand pip every version's wheel at once, which it rightly refuses.
+    _pv_wheel=$(_zopen_python_wheel_for_tag "$(_zopen_python_active_tag)")
+    if [ -z "${_pv_wheel}" ]; then
+      printSoftError "No wheel in dist/ matches Python ${_pv}"
+      deactivate
+      _zopen_python_check_rc=1
+      break
+    fi
+
+    # --force-reinstall so the freshly built wheel wins over anything cached
+    pip install --force-reinstall --no-deps "${_pv_wheel}"
+    python -m pytest -v
+    _pv_rc=$?
+
+    # Every interpreter's pytest output lands in the same check log, and
+    # zopen_check_results sums across runs, so totals aggregate on their own.
+    [ ${_pv_rc} -eq 0 ] || _zopen_python_check_rc=${_pv_rc}
+
+    deactivate
+  done
+
   return ${_zopen_python_check_rc}
 }
 
 _zopen_python_install() {
   mkdir -p "${ZOPEN_INSTALL_DIR}/lib/python"
   mkdir -p "${ZOPEN_INSTALL_DIR}/bin"
-  . .venv/bin/activate
+
+  # The pax carries exactly one interpreter's build: lib/python holds a single
+  # extension, and a second interpreter's .so would sit there unused. The
+  # primary version wins; every wheel is still published below.
+  _pv_primary=$(_zopen_python_primary_version)
+  _pv_venv=$(_zopen_python_venv_dir "${_pv_primary}")
+  . "${_pv_venv}/bin/activate" || return 1
+
+  _pv_wheel=$(_zopen_python_wheel_for_tag "$(_zopen_python_active_tag)")
+  if [ -z "${_pv_wheel}" ]; then
+    printSoftError "No wheel in dist/ matches the primary interpreter (${_pv_primary})"
+    deactivate
+    return 1
+  fi
+  printInfo "Installing $(basename "${_pv_wheel}") into the package tree"
+
   # Install the built wheel to the target directory
-  pip install --no-deps --target="${ZOPEN_INSTALL_DIR}/lib/python" dist/*.whl
+  pip install --no-deps --target="${ZOPEN_INSTALL_DIR}/lib/python" "${_pv_wheel}"
   # Symlink any scripts into bin/ so they are on PATH
   for f in "${ZOPEN_INSTALL_DIR}/lib/python/bin/"*; do
     [ -e "$f" ] || continue
@@ -879,9 +1074,12 @@ checkEnv()
     if ! command -V zopen_check_results > /dev/null 2>&1; then
       zopen_check_results() {
         dir="$1"; pfx="$2"; chk="$1/$2_check.log"
-        passed=$(grep -oE "[0-9]+ passed" "${chk}" | awk '{print $1}')
-        failed=$(grep -oE "[0-9]+ failed" "${chk}" | awk '{print $1}')
-        errors=$(grep -oE "[0-9]+ error" "${chk}" | awk '{print $1}')
+        # Sum across runs: with ZOPEN_PYTHON_VERSIONS set, every interpreter's
+        # pytest output lands in this one log, so a plain match would yield
+        # several numbers where the arithmetic below expects one.
+        passed=$(grep -oE "[0-9]+ passed" "${chk}" | awk '{s+=$1} END {print s+0}')
+        failed=$(grep -oE "[0-9]+ failed" "${chk}" | awk '{s+=$1} END {print s+0}')
+        errors=$(grep -oE "[0-9]+ error" "${chk}" | awk '{s+=$1} END {print s+0}')
         passed=${passed:-0}; failed=${failed:-0}; errors=${errors:-0}
         totalTests=$((passed + failed + errors))
         echo "actualFailures:$((failed + errors))"

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -377,6 +377,21 @@ _zopen_python_interpreter_path() {
     return 1
   fi
 
+  # An explicitly located runtime wins. check_python exports one of these per
+  # installed Python, because each version lives under its own prefix and only
+  # the primary ends up on PATH -- so a PATH lookup alone cannot find the rest.
+  _pi_var="ZOPEN_PYTHON_$(echo "$1" | tr '.' '_')"
+  # Stay silent on failure: this echoes the resolved path, so any diagnostic
+  # written here would be captured as if it were one. The caller reports.
+  _pi_path=$(eval "printf '%s' \"\${${_pi_var}:-}\"")
+  if [ -n "${_pi_path}" ]; then
+    if [ -x "${_pi_path}" ]; then
+      echo "${_pi_path}"
+      return 0
+    fi
+    return 1
+  fi
+
   _pi_path=$(command -v "python$1" 2> /dev/null)
   if [ -n "${_pi_path}" ]; then
     echo "${_pi_path}"
@@ -407,7 +422,15 @@ _zopen_python_verify_interpreters() {
   for _pv in $(_zopen_python_versions); do
     _pv_path=$(_zopen_python_interpreter_path "${_pv}")
     if [ -z "${_pv_path}" ]; then
-      _py_missing="${_py_missing} ${_pv}"
+      # Distinguish "nowhere to be found" from "you pointed us at something
+      # unusable", which is a different thing to go and fix.
+      _pv_var="ZOPEN_PYTHON_$(echo "${_pv}" | tr '.' '_')"
+      _pv_hint=$(eval "printf '%s' \"\${${_pv_var}:-}\"")
+      if [ -n "${_pv_hint}" ]; then
+        _py_missing="${_py_missing} ${_pv}(${_pv_var}=${_pv_hint} is not executable)"
+      else
+        _py_missing="${_py_missing} ${_pv}"
+      fi
       continue
     fi
 


### PR DESCRIPTION
## Summary

Build, test and publish one wheel per Python interpreter, so compiled ports can cover more than one Python version.

A compiled extension is bound to a single CPython ABI — `mmh3.cpython-312.so` is invisible to any other interpreter — so covering 3.12/3.13/3.14 means three builds and three wheels. This adds `ZOPEN_PYTHON_VERSIONS` to declare which. Left unset, everything runs against the active `python` exactly as today.

```sh
export ZOPEN_PYTHON_VERSIONS="3.12 3.13"   # first entry is the primary
```

## What changed

**Interpreter verification, before anything compiles.** Each declared version must be on `PATH` as `python<version>` *and* report the version it claims. Missing or mismatched interpreters fail the build with both problems listed. This is deliberately a hard failure: auto-detecting would let a node missing 3.13 quietly publish two wheels instead of three, and nobody would find out until a user hit "no matching distribution".

**One virtual environment per interpreter.** The primary keeps the plain `.venv` name, so the existing single-interpreter layout and any port referencing `.venv` are unaffected; others get `.venv-<version>`.

**Build and test per interpreter.** Tests run on every interpreter rather than just the primary, because the index is immutable per filename — an untested wheel that turns out to be broken can't be quietly replaced, only deleted or superseded by a version bump. A pure-Python wheel is identical whatever built it, so it is built once and shared, but still tested against each interpreter.

**Fixed three `dist/*.whl` globs.** The check and install phases handed pip *every* version's wheel at once, which pip rightly refuses. They now select the wheel matching the interpreter in use. The package tree receives the primary interpreter's wheel — `lib/python` can only hold one extension — while every wheel is staged for publication.

**Test results now sum across runs.** All interpreters' pytest output lands in one check log, where the previous single-match parse would feed several numbers to arithmetic expecting one.

## Validation

Ran end-to-end against two real interpreters (3.13 and 3.14) with a genuine C extension:

```
dist/zdemo-1.0-cp313-none-any.whl   ->  zdemo.cpython-313-darwin.so   Tag: cp313-none-any
dist/zdemo-1.0-cp314-none-any.whl   ->  zdemo.cpython-314-darwin.so   Tag: cp314-none-any
```

- **check phase**: 3.13 installed the cp313 wheel, 3.14 installed the cp314 wheel, both passed — the case the old glob broke
- **pure Python**: built once, rebuild correctly skipped for the second interpreter, both venvs still created, both tested against the shared wheel
- **interpreter verification**: missing version, a `python3.14` that actually reports 3.13, and both at once — each fails before compiling, listing every problem
- **wheel selection**: correct per tag, falls back to `py3-none-any`, returns non-zero on empty `dist/`; verified under `sh`, `bash` and `dash`
- **results aggregation**: single run unchanged (40 tests, 0 failures); three runs summed to 120 tests / 3 failures
- `sh -n bin/zopen-build`, `git diff --check`

## Interpreter discovery

Three sources, in order, so declaring a version works regardless of how the runtime is installed:

1. `ZOPEN_PYTHON_<major>_<minor>` — an explicit path, intended to be exported by `check_python`
2. `python<version>` on `PATH`
3. `python3`/`python` on `PATH`, when one of them reports the requested version

Each is version-verified by running the interpreter, so a wrong or stale entry is rejected rather than silently trusted.

The third source matters because IBM Open Enterprise Python may install only an unversioned `python3` — without it, a port could not pin the very version it was already building with. The first matters because `check_python` puts a single Python's `bin` on `PATH` while IBM installs each version under its own prefix, so a `PATH` lookup alone cannot find any interpreter but the primary.

Adding every prefix to `PATH` deliberately isn't the approach: each ships its own `python3`/`pip3`, so stacking them lets `pip3` resolve to a different runtime than `python3`. Activating a per-interpreter venv already puts the right `bin` first, so `PATH` is left alone.

A companion change to [check_pythonport](https://github.com/zopencommunity/check_pythonport) is needed to export those variables and add each runtime's `lib` to `LIBPATH`; that is a separate PR and not required for single-interpreter builds.

## Notes

- No behaviour change for ports that don't set `ZOPEN_PYTHON_VERSIONS`.
- The build node needs every declared interpreter installed. Since zopen builds against IBM Open Enterprise Python rather than shipping its own, the available versions are determined by what's installed there.
- Of the current Python ports, only `python-xxhash` and `mmh3` are compiled; `conan`, `meson` and `depot_tools` are pure Python and already publish a single portable wheel.
- Multi-interpreter builds are not yet exercised on z/OS — the end-to-end runs above used CPython 3.13/3.14 on macOS. Single-interpreter behaviour is unchanged and is the path currently in use.
