### PR TITLE
feat(pax2rpm): flatten Zopen paths and replace prefix placeholders

### DIFF
--- a/bin/zopen-pax2rpm
+++ b/bin/zopen-pax2rpm
@@ -340,6 +340,41 @@ for docfile in README* LICENSE* COPYING* CHANGELOG* AUTHORS* INSTALL* NEWS*; do
     fi
 done
 
+# ==============================================================================
+# --- Define the replacement and flattening function ---
+# ==============================================================================
+replaceAndFlattenHardcodedPath() {
+  orig=$1
+  replaced=$2
+  f=$3
+
+  if /bin/sed -e "" "${f}" 2> /dev/null 1>&2; then
+    isWritable=true
+    if [ ! -w "$f" ]; then
+      isWritable=false
+      chmod "+w" "$f"
+    fi
+
+    cp "$f" "$f.tmp" && \
+    /bin/sed \
+      -e "s#${orig}/\([^/]*\)/\1#${replaced}#g" \
+      -e "s#${orig}#${replaced}#g" \
+      "$f.tmp" > "$f" && \
+    rm -f "$f.tmp"
+    if ! $isWritable; then
+      chmod "-w" "$f"
+    fi
+  fi
+}
+# ==============================================================================
+# --- Scan and replace placeholders under %{buildroot} ---
+# ==============================================================================
+echo "Flattening Zopen paths and replacing placeholders under %{buildroot}..."
+find "%{buildroot}" -type f | while read -r file; do
+    [ -L "$file" ] && continue
+    replaceAndFlattenHardcodedPath "ZOPEN_INSTALL_PREFIX" "%{_prefix}" "$file"
+done
+
 # Generate RPM file list — standard Fedora/RHEL approach:
 # Use find to enumerate every file installed under %{buildroot}, then
 # strip the buildroot prefix with sed to get package-relative paths.


### PR DESCRIPTION
For RPM packaging builds
- Safely replace ZOPEN_INSTALL_PREFIX with the target prefix in text files.
- Flatten nested package directories (e.g. name/name) to flat FHS paths.

<!--
Before submitting a Pull Request, please ensure you've done the following:
- 📖 Read the zopen community Contributing Guide: https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md
- 📖 Read the zopen community Code of Conduct: https://github.com/zopencommunity/meta/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs when possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 💬 For major changes, consider discussing with the maintainers beforehand.
- [ ] Ensure all tests pass locally.
- [ ] Add tests for any new functionality.
- [ ] Ensure code complies with the project's licensing requirements.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen build framework
- [x] zopen package manager
- [ ] Documentation
- [ ] CI/CD
- [ ] Tools

## Description
<!-- Provide a comprehensive description summarizing the pull request -->

## Related Issues

- Related Issue #
- Closes #

## [optional] Are there any post-deployment tasks or follow-up actions required?
